### PR TITLE
feat: add `install_dependencies` command

### DIFF
--- a/src/commands/install_dependencies.yml
+++ b/src/commands/install_dependencies.yml
@@ -1,0 +1,66 @@
+description: >
+  Install dependencies with caching, optionally choose a package manager.
+  Requires execution environment with Node.js >= 16.17 pre-installed.
+
+parameters:
+  pkg_manager:
+    type: enum
+    enum: ['npm', 'pnpm']
+    default: 'npm'
+    description: Choose Node.js package manager to use.
+  pkg_json_dir:
+    type: string
+    default: '.'
+    description: >
+      Path to the directory containing package.json file.
+      Not needed when package.json is in the root.
+  cache_version:
+    type: string
+    default: 'v1'
+    description: >
+      Change the default cache version if the cache needs to be cleared for some reason.
+
+steps:
+  - run:
+      name: Ensure package manager
+      environment:
+        PKG_MANAGER: <<parameters.pkg_manager>>
+      command: <<include(scripts/ensure-pkg-manager.sh)>>
+  - run:
+      name: Check for package.json
+      working_directory: <<parameters.pkg_json_dir>>
+      command: <<include(scripts/check-pkg-json.sh)>>
+  - run:
+      name: Process lockfile
+      working_directory: <<parameters.pkg_json_dir>>
+      command: <<include(scripts/process-lockfile.sh)>>
+  - restore_cache:
+      keys:
+        - node-{{ arch }}-<<parameters.cache_version>>-{{ .Branch }}-{{ checksum "/tmp/node-lockfile" }}
+        - node-{{ arch }}-<<parameters.cache_version>>-{{ .Branch }}-
+        - node-{{ arch }}-<<parameters.cache_version>>-
+  - run:
+      name: Install dependencies
+      working_directory: <<parameters.pkg_json_dir>>
+      environment:
+        PKG_MANAGER: <<parameters.pkg_manager>>
+      command: <<include(scripts/install-dependencies.sh)>>
+  - when:
+      condition:
+        equal: [npm, <<parameters.pkg_manager>>]
+      steps:
+        - save_cache:
+            key: node-{{ arch }}-<<parameters.cache_version>>-{{ .Branch }}-{{ checksum "/tmp/node-lockfile" }}
+            paths:
+              - ~/.npm
+  - when:
+      condition:
+        equal: [pnpm, <<parameters.pkg_manager>>]
+      steps:
+        - save_cache:
+            key: node-{{ arch }}-<<parameters.cache_version>>-{{ .Branch }}-{{ checksum "/tmp/node-lockfile" }}
+            paths:
+              - ~/.pnpm-store
+  - run:
+      name: Remove temporary lockfile
+      command: rm -f /tmp/node-lockfile

--- a/src/scripts/check-pkg-json.sh
+++ b/src/scripts/check-pkg-json.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ! -f "package.json" ]; then
+  echo
+  echo "File package.json not found inside current directory: $(pwd)"
+  echo
+  echo "Content of current directory:"
+  echo 
+  ls
+  exit 1
+fi

--- a/src/scripts/ensure-pkg-manager.sh
+++ b/src/scripts/ensure-pkg-manager.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ "$PKG_MANAGER" == "pnpm" ]]; then
+  if ! pnpm --version | grep -q "^[0-9]"; then
+    echo "Installing pnpm using Corepack"
+    corepack enable
+    corepack prepare pnpm@latest --activate
+  fi
+
+  echo "Setting ~/.pnpm-store as the store directory"
+  pnpm config set store-dir ~/.pnpm-store
+fi

--- a/src/scripts/install-dependencies.sh
+++ b/src/scripts/install-dependencies.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ "$PKG_MANAGER" == "npm" ]]; then
+  npm ci
+elif [[ "$PKG_MANAGER" == "pnpm" ]]; then
+  pnpm i --frozen-lockfile
+fi

--- a/src/scripts/process-lockfile.sh
+++ b/src/scripts/process-lockfile.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+DEST_FILE="/tmp/node-project-lock"
+
+if [ -f "package-lock.json" ]; then
+  echo "Found package-lock.json, assuming lockfile"
+  cp package-lock.json $DEST_FILE
+elif [ -f "pnpm-lock.yaml" ]; then
+  echo "Found pnpm-lock.ymal, assuming lockfile"
+  cp pnpm-lock.yaml $DEST_FILE
+fi


### PR DESCRIPTION
The command for installing dependencies of a Node.js project. Supports npm and pnpm package managers. Caching is enabled by default and cannot be turned off. Requires execution environment with Node.js >= 16.17 pre-installed.