### PR TITLE
ci: add test jobs

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,4 +1,5 @@
 version: 2.1
+
 orbs:
   # Your orb will be automatically injected here during the pipeline.
   # Reference your orb's jobs and commands below as they will exist when built.
@@ -29,12 +30,74 @@ jobs:
       - checkout
       # Run your orb's commands to validate them.
       - core/greet
+  install-dependencies-npm-node-16:
+    executor:
+      name: core/default
+      tag: '16.20'
+    steps:
+      - checkout
+      - core/install_dependencies:
+          pkg_json_dir: ~/project/sample
+          cache_version: node16_v7
+      - run: cd ~/project/sample && npm run build
+  install-dependencies-pnpm-node-16:
+    executor:
+      name: core/default
+      tag: '16.20'
+    steps:
+      - checkout
+      - core/install_dependencies:
+          pkg_manager: pnpm
+          pkg_json_dir: ~/project/sample
+          cache_version: node16_v7
+      - run: cd ~/project/sample && pnpm run build
+  install-dependencies-custom-command:
+    executor: core/default
+    steps:
+      - checkout
+      - core/install_dependencies:
+          pkg_json_dir: ~/project/sample
+          install_command: npm install
+          cache_version: v9
+      - run: cd ~/project/sample && npm run build
+  run-script-npm:
+    executor: core/default
+    steps:
+      - core/run_script:
+          pkg_json_dir: ~/project/sample
+          script: test -- --json --outputFile=results_npm.json
+      - run:
+          name: Print output file
+          working_directory: ~/project/sample
+          command: cat results_npm.json
+  run-script-pnpm:
+    executor: core/default
+    steps:
+      - core/run_script:
+          pkg_manager: pnpm
+          pkg_json_dir: ~/project/sample
+          script: test --json --outputFile=results_pnpm.json
+      - run:
+          name: Print output file
+          working_directory: ~/project/sample
+          command: cat results_pnpm.json
+
 workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
       # Test your orb's commands in a custom job and test your orb's jobs directly as a part of this workflow.
       - command-test:
+          filters: *filters
+      - install-dependencies-npm-node-16:
+          filters: *filters
+      - install-dependencies-pnpm-node-16:
+          filters: *filters
+      - install-dependencies-custom-command:
+          filters: *filters
+      - run-script-npm:
+          filters: *filters
+      - run-script-pnpm:
           filters: *filters
       # The orb must be re-packed for publishing, and saved to the workspace.
       - orb-tools/pack:
@@ -47,5 +110,10 @@ workflows:
           requires:
             - orb-tools/pack
             - command-test
+            - install-dependencies-npm-node-16
+            - install-dependencies-pnpm-node-16
+            - install-dependencies-custom-command
+            - run-script-npm
+            - run-script-pnpm
           context: orb-publishing
           filters: *release-filters

--- a/sample/pnpm-lock.yaml
+++ b/sample/pnpm-lock.yaml
@@ -197,7 +197,6 @@ packages:
   /@babel/parser@7.23.6:
     resolution: {integrity: sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==}
     engines: {node: '>=6.0.0'}
-    hasBin: true
     dependencies:
       '@babel/types': 7.23.6
     dev: true
@@ -796,7 +795,6 @@ packages:
   /acorn@8.11.2:
     resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
     engines: {node: '>=0.4.0'}
-    hasBin: true
     dev: true
 
   /ajv-formats@2.1.1(ajv@8.12.0):
@@ -984,7 +982,6 @@ packages:
   /browserslist@4.22.2:
     resolution: {integrity: sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001570
       electron-to-chromium: 1.4.613
@@ -1121,7 +1118,6 @@ packages:
   /create-jest@29.7.0(@types/node@20.10.4)(ts-node@10.9.2):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
@@ -1227,7 +1223,6 @@ packages:
   /esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
-    hasBin: true
     dev: true
 
   /event-target-shim@5.0.1:
@@ -1471,7 +1466,6 @@ packages:
   /import-local@3.1.0:
     resolution: {integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==}
     engines: {node: '>=8'}
-    hasBin: true
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
@@ -1632,7 +1626,6 @@ packages:
   /jest-cli@29.7.0(@types/node@20.10.4)(ts-node@10.9.2):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
     peerDependenciesMeta:
@@ -1984,7 +1977,6 @@ packages:
   /jest@29.7.0(@types/node@20.10.4)(ts-node@10.9.2):
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
     peerDependenciesMeta:
@@ -2008,7 +2000,6 @@ packages:
 
   /js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
-    hasBin: true
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -2017,7 +2008,6 @@ packages:
   /jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
-    hasBin: true
     dev: true
 
   /json-parse-even-better-errors@2.3.1:
@@ -2037,7 +2027,6 @@ packages:
   /json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
-    hasBin: true
     dev: true
 
   /kleur@3.0.3:
@@ -2247,7 +2236,6 @@ packages:
 
   /pino@8.17.1:
     resolution: {integrity: sha512-YoN7/NJgnsJ+fkADZqjhRt96iepWBndQHeClmSBH0sQWCb8zGD74t00SK4eOtKFi/f8TUmQnfmgglEhd2kI1RQ==}
-    hasBin: true
     dependencies:
       atomic-sleep: 1.0.0
       fast-redact: 3.3.0
@@ -2374,7 +2362,6 @@ packages:
 
   /resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
-    hasBin: true
     dependencies:
       is-core-module: 2.13.1
       path-parse: 1.0.7
@@ -2416,13 +2403,11 @@ packages:
 
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
     dev: true
 
   /semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
-    hasBin: true
     dependencies:
       lru-cache: 6.0.0
 
@@ -2599,7 +2584,6 @@ packages:
   /ts-jest@29.1.1(@babel/core@7.23.6)(jest@29.7.0)(typescript@5.3.3):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
     peerDependencies:
       '@babel/core': '>=7.0.0-beta.0 <8'
       '@jest/types': ^29.0.0
@@ -2632,7 +2616,6 @@ packages:
 
   /ts-node@10.9.2(@types/node@20.10.4)(typescript@5.3.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
     peerDependencies:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
@@ -2674,7 +2657,6 @@ packages:
   /typescript@5.3.3:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
-    hasBin: true
     dev: true
 
   /undici-types@5.26.5:
@@ -2683,7 +2665,6 @@ packages:
 
   /update-browserslist-db@1.0.13(browserslist@4.22.2):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
-    hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
@@ -2720,7 +2701,6 @@ packages:
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
-    hasBin: true
     dependencies:
       isexe: 2.0.0
     dev: true

--- a/src/commands/install_dependencies.yml
+++ b/src/commands/install_dependencies.yml
@@ -1,6 +1,6 @@
 description: >
   Install dependencies with caching, optionally choose a package manager.
-  Requires execution environment with Node.js >= 16.17 pre-installed.
+  Requires execution environment with Node.js >= 16.20 pre-installed.
 
 parameters:
   pkg_manager:
@@ -14,6 +14,12 @@ parameters:
     description: >
       Path to the directory containing package.json file.
       Not needed when package.json is in the root.
+  install_command:
+    type: string
+    default: ''
+    description: >
+      Custom command to install dependencies. Useful when default commands,
+      "npm ci" or "pnpm i --frozen-lockfile", are unsuitable.
   cache_version:
     type: string
     default: 'v1'
@@ -33,6 +39,8 @@ steps:
   - run:
       name: Process lockfile
       working_directory: <<parameters.pkg_json_dir>>
+      environment:
+        PKG_MANAGER: <<parameters.pkg_manager>>
       command: <<include(scripts/process-lockfile.sh)>>
   - restore_cache:
       keys:
@@ -44,6 +52,7 @@ steps:
       working_directory: <<parameters.pkg_json_dir>>
       environment:
         PKG_MANAGER: <<parameters.pkg_manager>>
+        INSTALL_CMD: <<parameters.install_command>>
       command: <<include(scripts/install-dependencies.sh)>>
   - when:
       condition:

--- a/src/commands/run_script.yml
+++ b/src/commands/run_script.yml
@@ -14,6 +14,12 @@ parameters:
     description: >
       Path to the directory containing package.json file.
       Not needed when package.json is in the root.
+  install_command:
+    type: string
+    default: ''
+    description: >
+      Custom command to install dependencies. Useful when default commands,
+      "npm ci" or "pnpm i --frozen-lockfile", are unsuitable.
   cache_version:
     type: string
     default: 'v1'
@@ -31,9 +37,11 @@ steps:
   - install_dependencies:
       pkg_manager: <<parameters.pkg_manager>>
       pkg_json_dir: <<parameters.pkg_json_dir>>
+      install_command: <<parameters.install_command>>
       cache_version: <<parameters.cache_version>>
   - run:
-      name: Run <<parameters.pkg_manager>> <<parameters.script>>
+      name: Run "<<parameters.script>>" with "<<parameters.pkg_manager>>"
+      working_directory: <<parameters.pkg_json_dir>>
       environment:
         PKG_MANAGER: <<parameters.pkg_manager>>
         SCRIPT: <<parameters.script>>

--- a/src/scripts/check-pkg-json.sh
+++ b/src/scripts/check-pkg-json.sh
@@ -6,6 +6,6 @@ if [ ! -f "package.json" ]; then
   echo
   echo "Content of current directory:"
   echo 
-  ls
+  ls -al
   exit 1
 fi

--- a/src/scripts/ensure-pkg-manager.sh
+++ b/src/scripts/ensure-pkg-manager.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 if [[ "$PKG_MANAGER" == "pnpm" ]]; then
-  if ! pnpm --version | grep -q "^[0-9]"; then
-    echo "Installing pnpm using Corepack"
-    corepack enable
+  if ! pnpm --version | grep -E "^([8-9]|[1-9][0-9]{1,})\."; then
+    echo "Appropriate version of pnpm not found, installing latest"
+    corepack enable || sudo corepack enable
     corepack prepare pnpm@latest --activate
   fi
 

--- a/src/scripts/install-dependencies.sh
+++ b/src/scripts/install-dependencies.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-if [[ "$PKG_MANAGER" == "npm" ]]; then
+if [[ -n "$INSTALL_CMD" ]]; then
+  echo "Running custom install command:"
+  eval "$INSTALL_CMD"
+elif [[ "$PKG_MANAGER" == "npm" ]]; then
   npm ci
 elif [[ "$PKG_MANAGER" == "pnpm" ]]; then
   pnpm i --frozen-lockfile

--- a/src/scripts/process-lockfile.sh
+++ b/src/scripts/process-lockfile.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-DEST_FILE="/tmp/node-project-lock"
+DEST_FILE="/tmp/node-lockfile"
 
-if [ -f "package-lock.json" ]; then
+if [ -f "package-lock.json" ] && [[ "$PKG_MANAGER" == "npm" ]]; then
   echo "Found package-lock.json, assuming lockfile"
-  cp package-lock.json $DEST_FILE
-elif [ -f "pnpm-lock.yaml" ]; then
+  cp package-lock.json "$DEST_FILE"
+elif [ -f "pnpm-lock.yaml" ] && [[ "$PKG_MANAGER" == "pnpm" ]]; then
   echo "Found pnpm-lock.ymal, assuming lockfile"
-  cp pnpm-lock.yaml $DEST_FILE
+  cp pnpm-lock.yaml "$DEST_FILE"
 fi

--- a/src/scripts/run-script.sh
+++ b/src/scripts/run-script.sh
@@ -1,7 +1,3 @@
 #!/bin/bash
 
-if [[ "$PKG_MANAGER" == "npm" ]]; then
-  npm run "$SCRIPT"
-elif [[ "$PKG_MANAGER" == "pnpm" ]]; then
-  pnpm run "$SCRIPT"
-fi
+eval "$PKG_MANAGER" run "$SCRIPT"


### PR DESCRIPTION
Test jobs for `install_dependencies` and `run_script` commands. Bugs encountered along the way were addressed as a part of this change for convenience reasons, thus this large diff.