### PR TITLE
chore: add examples

### DIFF
--- a/src/examples/npm_run.yml
+++ b/src/examples/npm_run.yml
@@ -1,0 +1,18 @@
+description: |
+  Run any script defined inside a "package.json" using the targeted package manager.
+  Before running the specified script, the command will fetch the code and install dependencies.
+usage:
+  version: 2.1
+  orbs:
+    core: studion/core@x.y.z
+  jobs:
+    test:
+      executor: core/node
+      steps:
+        - core/run_script:
+            pkg_manager: npm
+            cript: test
+  workflows:
+    test_app:
+      jobs:
+        - test

--- a/src/examples/pnpm_install.yml
+++ b/src/examples/pnpm_install.yml
@@ -1,0 +1,26 @@
+description: |
+  By default, the "install_dependencies" command respects automated environments
+  and installs dependencies consistently and predictably.
+  There is an option to override the install command, package manager, and root directory.
+usage:
+  version: 2.1
+  orbs:
+    core: studion/core@x.y.z
+  jobs:
+    build:
+      executor:
+        name: core/node
+        tag: 20.11.0
+        resource_class: xlarge
+      steps:
+        - checkout
+        - core/install_dependencies:
+            pkg_manager: pnpm
+            pkg_json_dir: ~/workspace/project
+            install_command: pnpm i
+            cache_version: v3
+        - run: cd ~/workspace/project && pnpm run build
+  workflows:
+    build_app:
+      jobs:
+        - build


### PR DESCRIPTION
Examples for the `install_dependencies` and `run_script` commands.