### PR TITLE
feat: add `ensure_pkg_manager` command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -15,6 +15,62 @@ release-filters: &release-filters
     only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
 jobs:
+  ensure-npm-version:
+    executor: core/node
+    steps:
+      - core/ensure_pkg_manager:
+          ref: npm@latest
+      - run:
+          name: Validate version
+          command: |
+            NPM_LATEST_VERSION=$(npm view npm version)
+            if ! npm --version | grep -q "$NPM_LATEST_VERSION"; then
+              echo "npm version $NPM_LATEST_VERSION not found"
+              exit 1
+            fi
+  ensure-pnpm-version-node-16:
+    executor:
+      name: core/node
+      tag: '16.20'
+    steps:
+      - core/ensure_pkg_manager:
+          ref: pnpm@8.8.0
+      - run:
+          name: Validate version
+          command: |
+            if ! pnpm --version | grep -q "8.8.0"; then
+              echo "pnpm version 8.8.0 not found"
+              exit 1
+            fi
+  ensure-pnpm-version-node-18:
+    executor:
+      name: core/node
+      tag: '18.19'
+    steps:
+      - core/ensure_pkg_manager:
+          ref: pnpm@9.0.1
+      - run:
+          name: Validate version
+          command: |
+            if ! pnpm --version | grep -q "9.0.1"; then
+              echo "pnpm version 9.0.1 not found"
+              exit 1
+            fi
+  ensure-pnpm-latest:
+    executor: core/node
+    steps:
+      - checkout
+      - run: cd sample
+      - core/ensure_pkg_manager:
+          ref: pnpm
+      - run:
+          name: Validate version
+          command: |
+            PNPM_LATEST_VERSION=$(npm view pnpm version)
+            if ! pnpm --version | grep -q "$PNPM_LATEST_VERSION"; then
+              echo "pnpm version $PNPM_LATEST_VERSION not found"
+              exit 1
+            fi
   install-dependencies-npm-node-16:
     executor:
       name: core/node
@@ -22,6 +78,7 @@ jobs:
     steps:
       - checkout
       - core/install_dependencies:
+          pkg_manager: npm
           pkg_json_dir: ~/project/sample
           cache_version: node16_v7
       - run: cd ~/project/sample && npm run build
@@ -32,7 +89,7 @@ jobs:
     steps:
       - checkout
       - core/install_dependencies:
-          pkg_manager: pnpm
+          pkg_manager: pnpm@latest-8
           pkg_json_dir: ~/project/sample
           cache_version: node16_v7
       - run: cd ~/project/sample && pnpm run build
@@ -41,6 +98,7 @@ jobs:
     steps:
       - checkout
       - core/install_dependencies:
+          pkg_manager: npm
           pkg_json_dir: ~/project/sample
           install_command: npm install
           cache_version: v9
@@ -49,6 +107,7 @@ jobs:
     executor: core/node
     steps:
       - core/run_script:
+          pkg_manager: npm
           pkg_json_dir: ~/project/sample
           script: test -- --json --outputFile=results_npm.json
       - run:
@@ -70,6 +129,14 @@ jobs:
 workflows:
   test-deploy:
     jobs:
+      - ensure-npm-version:
+          filters: *filters
+      - ensure-pnpm-version-node-16:
+          filters: *filters
+      - ensure-pnpm-version-node-18:
+          filters: *filters
+      - ensure-pnpm-latest:
+          filters: *filters
       - install-dependencies-npm-node-16:
           filters: *filters
       - install-dependencies-pnpm-node-16:
@@ -88,6 +155,10 @@ workflows:
           pub_type: production
           requires:
             - orb-tools/pack
+            - ensure-npm-version
+            - ensure-pnpm-version-node-16
+            - ensure-pnpm-version-node-18
+            - ensure-pnpm-latest
             - install-dependencies-npm-node-16
             - install-dependencies-pnpm-node-16
             - install-dependencies-custom-command

--- a/src/commands/ensure_pkg_manager.yml
+++ b/src/commands/ensure_pkg_manager.yml
@@ -1,0 +1,23 @@
+description: >
+  Ensure required package manager is in place, optionally specifing the exact version.
+  Requires execution environment with Node.js >= 16.17 pre-installed.
+
+parameters:
+  ref:
+    type: string
+    default: $DEFAULT_PKG_MANAGER
+    description: |
+      Choose Node.js package manager to use. Supports npm and pnpm.
+      The package manager must follow the format <name>[@<version|tag>].
+      Omitting the version implies that the npm version is determined by the target Node.js environment,
+      while pnpm will default to the latest version.
+
+steps:
+  - run:
+      name: Check Node.js version
+      command: <<include(scripts/check-node-version.sh)>>
+  - run:
+      name: Ensure package manager
+      environment:
+        PKG_MANAGER: <<parameters.ref>>
+      command: <<include(scripts/ensure-pkg-manager.sh)>>

--- a/src/commands/install_dependencies.yml
+++ b/src/commands/install_dependencies.yml
@@ -1,13 +1,16 @@
 description: >
   Install dependencies with caching, optionally choose a package manager.
-  Requires execution environment with Node.js >= 16.20 pre-installed.
+  Requires execution environment with Node.js >= 16.17 pre-installed.
 
 parameters:
   pkg_manager:
-    type: enum
-    enum: ['npm', 'pnpm']
-    default: 'npm'
-    description: Choose Node.js package manager to use.
+    type: string
+    default: $DEFAULT_PKG_MANAGER
+    description: |
+      Choose Node.js package manager to use. Supports npm and pnpm.
+      The package manager must follow the format <name>[@<version|tag>].
+      Omitting the version implies that the npm version is determined by the target Node.js environment,
+      while pnpm will default to the latest version.
   pkg_json_dir:
     type: string
     default: '.'
@@ -23,15 +26,11 @@ parameters:
   cache_version:
     type: string
     default: 'v1'
-    description: >
-      Change the default cache version if the cache needs to be cleared for some reason.
+    description: Change the default cache version if the cache needs to be cleared for some reason.
 
 steps:
-  - run:
-      name: Ensure package manager
-      environment:
-        PKG_MANAGER: <<parameters.pkg_manager>>
-      command: <<include(scripts/ensure-pkg-manager.sh)>>
+  - ensure_pkg_manager:
+      ref: <<parameters.pkg_manager>>
   - run:
       name: Check for package.json
       working_directory: <<parameters.pkg_json_dir>>
@@ -39,8 +38,6 @@ steps:
   - run:
       name: Process lockfile
       working_directory: <<parameters.pkg_json_dir>>
-      environment:
-        PKG_MANAGER: <<parameters.pkg_manager>>
       command: <<include(scripts/process-lockfile.sh)>>
   - restore_cache:
       keys:
@@ -51,12 +48,11 @@ steps:
       name: Install dependencies
       working_directory: <<parameters.pkg_json_dir>>
       environment:
-        PKG_MANAGER: <<parameters.pkg_manager>>
         INSTALL_CMD: <<parameters.install_command>>
       command: <<include(scripts/install-dependencies.sh)>>
   - when:
       condition:
-        equal: [npm, <<parameters.pkg_manager>>]
+        matches: { pattern: "^npm(.{0,})?$", value: <<parameters.pkg_manager>> }
       steps:
         - save_cache:
             key: node-{{ arch }}-<<parameters.cache_version>>-{{ .Branch }}-{{ checksum "/tmp/node-lockfile" }}
@@ -64,7 +60,7 @@ steps:
               - ~/.npm
   - when:
       condition:
-        equal: [pnpm, <<parameters.pkg_manager>>]
+        matches: { pattern: "^pnpm(.{0,})?$", value: <<parameters.pkg_manager>> }
       steps:
         - save_cache:
             key: node-{{ arch }}-<<parameters.cache_version>>-{{ .Branch }}-{{ checksum "/tmp/node-lockfile" }}

--- a/src/commands/run_script.yml
+++ b/src/commands/run_script.yml
@@ -4,10 +4,13 @@ description: >
 
 parameters:
   pkg_manager:
-    type: enum
-    enum: ['npm', 'pnpm']
-    default: 'npm'
-    description: Choose Node.js package manager to use.
+    type: string
+    default: $DEFAULT_PKG_MANAGER
+    description: |
+      Choose Node.js package manager to use. Supports npm and pnpm.
+      The package manager must follow the format <name>[@<version|tag>].
+      Omitting the version implies that the npm version is determined by the target Node.js environment,
+      while pnpm will default to the latest version.
   pkg_json_dir:
     type: string
     default: '.'
@@ -23,8 +26,7 @@ parameters:
   cache_version:
     type: string
     default: 'v1'
-    description: >
-      Change the default cache version if the cache needs to be cleared for some reason.
+    description: Change the default cache version if the cache needs to be cleared for some reason.
   script:
     type: string
     default: ''
@@ -43,7 +45,6 @@ steps:
       name: Run "<<parameters.script>>" with "<<parameters.pkg_manager>>"
       working_directory: <<parameters.pkg_json_dir>>
       environment:
-        PKG_MANAGER: <<parameters.pkg_manager>>
         SCRIPT: <<parameters.script>>
       command: <<include(scripts/run-script.sh)>>
 

--- a/src/examples/pnpm_ensure.yml
+++ b/src/examples/pnpm_ensure.yml
@@ -1,0 +1,20 @@
+description: |
+  Ensure the desired package manager, including the version, is installed on the system.
+  If desired the package manager can be set through the DEFAULT_PKG_MANAGER environment variable.
+  The pnpm is installed using the Corepack, while the npm is used to update itself when required.
+
+usage:
+  version: 2.1
+  orbs:
+    core: studion/core@x.y.z
+  jobs:
+    audit:
+      executor: core/node
+      steps:
+        - core/ensure_pkg_manager:
+            ref: pnpm@9.0.1
+        - run: pnpm audit --prod
+  workflows:
+    audit_deps:
+      jobs:
+        - audit

--- a/src/scripts/check-node-version.sh
+++ b/src/scripts/check-node-version.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+NODE_VERSION_REGEX="v([0-9]+).([0-9]+).([0-9]+)"
+NODE_VERSION=$(node -v)
+
+if [[ "$NODE_VERSION" =~ $NODE_VERSION_REGEX ]]; then
+  MAJOR="${BASH_REMATCH[1]}"
+  MINOR="${BASH_REMATCH[2]}"
+
+  if [[ "$MAJOR" -lt 16 || ("$MAJOR" -eq 16 && "$MINOR" -lt 17) ]]; then
+    echo "At least Node.js v16.20 is required!"
+    exit 1
+  fi
+fi

--- a/src/scripts/ensure-pkg-manager.sh
+++ b/src/scripts/ensure-pkg-manager.sh
@@ -1,12 +1,82 @@
 #!/bin/bash
 
-if [[ "$PKG_MANAGER" == "pnpm" ]]; then
-  if ! pnpm --version | grep -E "^([8-9]|[1-9][0-9]{1,})\."; then
-    echo "Appropriate version of pnpm not found, installing latest"
-    corepack enable || sudo corepack enable
-    corepack prepare pnpm@latest --activate
+SUDO="sudo"
+
+if [[ $EUID == 0 ]]; then
+  SUDO=""
+fi
+
+PKG_MANAGER_WITH_VERSION_REGEX="(npm|pnpm)@(([0-9]+.?){0,2}[0-9]+|[a-z]+-?([0-9]+)?)"
+NAME="$PKG_MANAGER"
+VERSION=""
+
+if [[ "$PKG_MANAGER" =~ $PKG_MANAGER_WITH_VERSION_REGEX ]]; then
+  NAME="${BASH_REMATCH[1]}"
+  VERSION="${BASH_REMATCH[2]}"
+fi
+
+echo "export CURRENT_PKG_MANAGER='$NAME'" >> "$BASH_ENV"
+
+if [[ "$NAME" == "npm" ]]; then
+  if [[ -n "$VERSION" ]]; then
+    $SUDO npm i -g npm@"$VERSION"
+    echo "Required npm version: $VERSION"
+    echo "Installed npm version: $(npm --version)"
+  else
+    echo "Detected npm version: $(npm --version)"
   fi
+
+  exit 0
+fi
+
+if [[ "$NAME" == "pnpm" ]]; then
+  if command -v pnpm > /dev/null 2>&1; then
+    echo "Found pnpm installation, removing it"
+    $SUDO rm -rf "$(pnpm store path)" > /dev/null 2>&1
+    $SUDO rm -rf "$PNPM_HOME" > /dev/null 2>&1
+    $SUDO npm rm -g pnpm > /dev/null 2>&1
+  fi
+
+  export COREPACK_DEFAULT_TO_LATEST=0
+  $SUDO corepack enable pnpm
+
+  PNPM_VERSION=$(npm view pnpm version)
+
+  if [[ -n "$VERSION" ]]; then
+    PNPM_VERSION="$VERSION"
+  fi
+
+  COREPACK_VERSION_REGEX="([0-9]+).([0-9]+)."
+  COREPACK_VERSION=$(corepack -v)
+  LEGACY_MODE=false
+
+  if [[ "$COREPACK_VERSION" =~ $COREPACK_VERSION_REGEX ]]; then
+    MAJOR="${BASH_REMATCH[1]}"
+    MINOR="${BASH_REMATCH[2]}"
+
+    if [[ "$MAJOR" -eq 0 && "$MINOR" -lt 20 ]]; then
+      # Required for Node 16 support
+      LEGACY_MODE=true
+      echo "Using Corepack legacy mode"
+    fi
+  fi
+
+  if "$LEGACY_MODE"; then
+    corepack prepare pnpm@"$PNPM_VERSION" --activate
+  else
+    corepack install -g pnpm@"$PNPM_VERSION"
+  fi
+
+  echo "Required pnpm version: $PNPM_VERSION"
+  echo "Installed pnpm version: $(pnpm --version)"
 
   echo "Setting ~/.pnpm-store as the store directory"
   pnpm config set store-dir ~/.pnpm-store
+
+  exit 0
 fi
+
+echo "Failed to ensure package manager"
+echo "Please specify supported package manager through parameter or environment"
+
+exit 1

--- a/src/scripts/install-dependencies.sh
+++ b/src/scripts/install-dependencies.sh
@@ -3,8 +3,8 @@
 if [[ -n "$INSTALL_CMD" ]]; then
   echo "Running custom install command:"
   eval "$INSTALL_CMD"
-elif [[ "$PKG_MANAGER" == "npm" ]]; then
+elif [[ "$CURRENT_PKG_MANAGER" == "npm" ]]; then
   npm ci
-elif [[ "$PKG_MANAGER" == "pnpm" ]]; then
+elif [[ "$CURRENT_PKG_MANAGER" == "pnpm" ]]; then
   pnpm i --frozen-lockfile
 fi

--- a/src/scripts/process-lockfile.sh
+++ b/src/scripts/process-lockfile.sh
@@ -2,10 +2,10 @@
 
 DEST_FILE="/tmp/node-lockfile"
 
-if [ -f "package-lock.json" ] && [[ "$PKG_MANAGER" == "npm" ]]; then
+if [ -f "package-lock.json" ] && [[ "$CURRENT_PKG_MANAGER" == "npm" ]]; then
   echo "Found package-lock.json, assuming lockfile"
   cp package-lock.json "$DEST_FILE"
-elif [ -f "pnpm-lock.yaml" ] && [[ "$PKG_MANAGER" == "pnpm" ]]; then
+elif [ -f "pnpm-lock.yaml" ] && [[ "$CURRENT_PKG_MANAGER" == "pnpm" ]]; then
   echo "Found pnpm-lock.ymal, assuming lockfile"
   cp pnpm-lock.yaml "$DEST_FILE"
 fi

--- a/src/scripts/run-script.sh
+++ b/src/scripts/run-script.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-eval "$PKG_MANAGER" run "$SCRIPT"
+eval "$CURRENT_PKG_MANAGER" run "$SCRIPT"


### PR DESCRIPTION
The command to ensure the desired package manager is installed on the system. Optionally the version can be specified also. By default, look at the DEFAULT_PKG_MANAGER environment variable for the package manager definition.
Checks the Node.js meets the minimum required version before ensuring package manager installation.