### PR TITLE
feat: set `medium` as default resource class

### DIFF
--- a/src/executors/node.yml
+++ b/src/executors/node.yml
@@ -11,7 +11,7 @@ parameters:
   resource_class:
     type: enum
     enum: ['small', 'medium', 'medium+', 'large', 'xlarge', '2xlarge', '2xlarge+']
-    default: 'large'
+    default: 'medium'
     description: Choose the executor resource class
 
 docker:

--- a/src/executors/ubuntu.yml
+++ b/src/executors/ubuntu.yml
@@ -11,7 +11,7 @@ parameters:
   resource_class:
     type: enum
     enum: ['small', 'medium', 'medium+', 'large', 'xlarge', '2xlarge', '2xlarge+']
-    default: 'large'
+    default: 'medium'
     description: Choose the executor resource class
 
 docker:


### PR DESCRIPTION
Based on the current resource utilization data `medium` is a better fit.