### PR TITLE
chore: remove the `greet` script

### DIFF
--- a/src/scripts/greet.sh
+++ b/src/scripts/greet.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-# This example uses envsubst to support variable substitution in the string parameter type.
-# https://circleci.com/docs/orbs-best-practices/#accepting-parameters-as-strings-or-environment-variables
-TO=$(circleci env subst "${PARAM_TO}")
-# If for any reason the TO variable is not set, default to "World"
-echo "Hello ${TO:-World}!"


### PR DESCRIPTION
The leftover artifact of the `init` command that was missed by templates artifact removal change.