### PR TITLE
style: remove empty lines from `check-pkg-json` output

### DIFF
--- a/src/scripts/check-pkg-json.sh
+++ b/src/scripts/check-pkg-json.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
 if [ ! -f "package.json" ]; then
-  echo
   echo "File package.json not found inside current directory: $(pwd)"
-  echo
   echo "Content of current directory:"
-  echo 
   ls -al
   exit 1
 fi


### PR DESCRIPTION
Removes `echo` stements used to output empty lines.