### PR TITLE
fix: correct syntax to reference `DEFAULT_PKG_MANAGER` env

### DIFF
--- a/src/commands/ensure_pkg_manager.yml
+++ b/src/commands/ensure_pkg_manager.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   ref:
     type: string
-    default: $DEFAULT_PKG_MANAGER
+    default: ${DEFAULT_PKG_MANAGER}
     description: |
       Choose Node.js package manager to use. Supports npm and pnpm.
       The package manager must follow the format <name>[@<version|tag>].

--- a/src/commands/install_dependencies.yml
+++ b/src/commands/install_dependencies.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   pkg_manager:
     type: string
-    default: $DEFAULT_PKG_MANAGER
+    default: ${DEFAULT_PKG_MANAGER}
     description: |
       Choose Node.js package manager to use. Supports npm and pnpm.
       The package manager must follow the format <name>[@<version|tag>].

--- a/src/commands/run_script.yml
+++ b/src/commands/run_script.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   pkg_manager:
     type: string
-    default: $DEFAULT_PKG_MANAGER
+    default: ${DEFAULT_PKG_MANAGER}
     description: |
       Choose Node.js package manager to use. Supports npm and pnpm.
       The package manager must follow the format <name>[@<version|tag>].


### PR DESCRIPTION
Use correct syntax to pass `DEFAULT_PKG_MANAGER` as the default value of a parameter inside commands.