### PR TITLE
feat: remove corepack from pnpm version management

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An orb to facilitate Node.js work within Studion CircleCI pipelines. Inspired by CircleCI Node Orb.\
 Key features:
-- Support for pnpm using Corepack, and npm
+- Support for pnpm and npm
 - Ensure the specific version/tag of the package manager is installed
 - The default value of the package manager is picked from the environment
 - Install dependencies with caching enabled by default

--- a/src/examples/pnpm_ensure.yml
+++ b/src/examples/pnpm_ensure.yml
@@ -1,7 +1,7 @@
 description: |
   Ensure the desired package manager, including the version, is installed on the system.
   If desired the package manager can be set through the DEFAULT_PKG_MANAGER environment variable.
-  The pnpm is installed using the Corepack, while the npm is used to update itself when required.
+  The npm is used to update itself and to install pnpm when required.
 
 usage:
   version: 2.1

--- a/src/scripts/ensure-pkg-manager.sh
+++ b/src/scripts/ensure-pkg-manager.sh
@@ -37,35 +37,13 @@ if [[ "$NAME" == "pnpm" ]]; then
     $SUDO npm rm -g pnpm > /dev/null 2>&1
   fi
 
-  export COREPACK_DEFAULT_TO_LATEST=0
-  $SUDO corepack enable pnpm
-
   PNPM_VERSION=$(npm view pnpm version)
 
   if [[ -n "$VERSION" ]]; then
     PNPM_VERSION="$VERSION"
   fi
 
-  COREPACK_VERSION_REGEX="([0-9]+).([0-9]+)."
-  COREPACK_VERSION=$(corepack -v)
-  LEGACY_MODE=false
-
-  if [[ "$COREPACK_VERSION" =~ $COREPACK_VERSION_REGEX ]]; then
-    MAJOR="${BASH_REMATCH[1]}"
-    MINOR="${BASH_REMATCH[2]}"
-
-    if [[ "$MAJOR" -eq 0 && "$MINOR" -lt 20 ]]; then
-      # Required for Node 16 support
-      LEGACY_MODE=true
-      echo "Using Corepack legacy mode"
-    fi
-  fi
-
-  if "$LEGACY_MODE"; then
-    corepack prepare pnpm@"$PNPM_VERSION" --activate
-  else
-    corepack install -g pnpm@"$PNPM_VERSION"
-  fi
+  $SUDO npm i -g pnpm@"$PNPM_VERSION"
 
   echo "Required pnpm version: $PNPM_VERSION"
   echo "Installed pnpm version: $(pnpm --version)"


### PR DESCRIPTION
Since Corepack is being removed from Node.js, pnpm is now installed using npm.