### PR TITLE
feat: remove the checkout step from the script execution

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -106,6 +106,7 @@ jobs:
   run-script-npm:
     executor: core/node
     steps:
+      - checkout
       - core/run_script:
           pkg_manager: npm
           pkg_json_dir: ~/project/sample
@@ -117,6 +118,7 @@ jobs:
   run-script-pnpm:
     executor: core/node
     steps:
+      - checkout
       - core/run_script:
           pkg_manager: pnpm
           pkg_json_dir: ~/project/sample

--- a/src/commands/run_script.yml
+++ b/src/commands/run_script.yml
@@ -35,7 +35,6 @@ parameters:
       manager, meaning it can contain arguments as well.
 
 steps:
-  - checkout
   - install_dependencies:
       pkg_manager: <<parameters.pkg_manager>>
       pkg_json_dir: <<parameters.pkg_json_dir>>

--- a/src/examples/npm_run.yml
+++ b/src/examples/npm_run.yml
@@ -10,6 +10,7 @@ usage:
     test:
       executor: core/node
       steps:
+        - checkout
         - core/run_script:
             pkg_manager: npm
             script: test


### PR DESCRIPTION
The checkout step is removed from the `run_script` command to allow for better reusability.