### PR TITLE
fix: uniform `v16.20` as the minimum supported Node.js version

### DIFF
--- a/src/commands/ensure_pkg_manager.yml
+++ b/src/commands/ensure_pkg_manager.yml
@@ -1,6 +1,6 @@
 description: >
   Ensure required package manager is in place, optionally specifing the exact version.
-  Requires execution environment with Node.js >= 16.17 pre-installed.
+  Requires execution environment with Node.js >= 16.20 pre-installed.
 
 parameters:
   ref:

--- a/src/commands/install_dependencies.yml
+++ b/src/commands/install_dependencies.yml
@@ -1,6 +1,6 @@
 description: >
   Install dependencies with caching, optionally choose a package manager.
-  Requires execution environment with Node.js >= 16.17 pre-installed.
+  Requires execution environment with Node.js >= 16.20 pre-installed.
 
 parameters:
   pkg_manager:

--- a/src/commands/run_script.yml
+++ b/src/commands/run_script.yml
@@ -1,6 +1,6 @@
 description: >
   Simple command that enables running scripts defined within package.json.
-  Requires execution environment with Node.js >= 16.17 pre-installed.
+  Requires execution environment with Node.js >= 16.20 pre-installed.
 
 parameters:
   pkg_manager:

--- a/src/scripts/check-node-version.sh
+++ b/src/scripts/check-node-version.sh
@@ -7,7 +7,7 @@ if [[ "$NODE_VERSION" =~ $NODE_VERSION_REGEX ]]; then
   MAJOR="${BASH_REMATCH[1]}"
   MINOR="${BASH_REMATCH[2]}"
 
-  if [[ "$MAJOR" -lt 16 || ("$MAJOR" -eq 16 && "$MINOR" -lt 17) ]]; then
+  if [[ "$MAJOR" -lt 16 || ("$MAJOR" -eq 16 && "$MINOR" -lt 20) ]]; then
     echo "At least Node.js v16.20 is required!"
     exit 1
   fi


### PR DESCRIPTION
Resolves an inconsistency between documentation, tests, and version check for minimum supported Node.js version and seals it to `v16.20`.