### PR TITLE
feat: uniform package manager default version logic

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -41,6 +41,21 @@ jobs:
               echo "pnpm version $PNPM_LATEST_VERSION not found"
               exit 1
             fi
+  ensure-pnpm-fresh-install:
+    docker:
+      - image: node:lts-slim
+    resource_class: medium
+    steps:
+      - core/ensure_pkg_manager:
+          ref: pnpm
+      - run:
+          name: Validate version
+          command: |
+            PNPM_LATEST_VERSION=$(npm view pnpm version)
+            if ! pnpm --version | grep -q "$PNPM_LATEST_VERSION"; then
+              echo "pnpm version $PNPM_LATEST_VERSION not found"
+              exit 1
+            fi
   install-dependencies-npm-node-18:
     executor:
       name: core/node_secrets
@@ -70,7 +85,7 @@ jobs:
       - core/install_dependencies:
           pkg_manager: pnpm@10.5.1
           pkg_json_dir: ~/project/sample
-          install_command: npm install
+          install_command: pnpm install
           cache_version: v10
       - run: cd ~/project/sample && npm run build
   run-script-npm:
@@ -105,6 +120,8 @@ workflows:
           filters: *filters
       - ensure-pnpm-version:
           filters: *filters
+      - ensure-pnpm-fresh-install:
+          filters: *filters
       - install-dependencies-npm-node-18:
           filters: *filters
       - install-dependencies-pnpm-node-18:
@@ -125,6 +142,7 @@ workflows:
             - orb-tools/pack
             - ensure-npm-version
             - ensure-pnpm-version
+            - ensure-pnpm-fresh-install
             - install-dependencies-npm-node-18
             - install-dependencies-pnpm-node-18
             - install-dependencies-custom-command

--- a/src/commands/ensure_pkg_manager.yml
+++ b/src/commands/ensure_pkg_manager.yml
@@ -9,9 +9,9 @@ parameters:
     description: |
       Choose Node.js package manager to use. Supports npm and pnpm.
       The package manager must follow the format <name>[@<version|tag>].
-      Omitting the version implies that the npm version is determined by the target Node.js environment,
-      while pnpm will default to the latest version.
-
+      Omitting the version implies
+      (for npm) use the version that comes with the target Node.js environment,
+      (for pnpm) use the existing version if found, otherwise use the latest version.
 steps:
   - run:
       name: Check Node.js version

--- a/src/examples/pnpm_ensure.yml
+++ b/src/examples/pnpm_ensure.yml
@@ -1,6 +1,6 @@
 description: |
   Ensure the desired package manager, including the version, is installed on the system.
-  If desired the package manager can be set through the DEFAULT_PKG_MANAGER environment variable.
+  If desired, the package manager can be set through the DEFAULT_PKG_MANAGER environment variable.
   The npm is used to update itself and to install pnpm when required.
 
 usage:

--- a/src/scripts/ensure-pkg-manager.sh
+++ b/src/scripts/ensure-pkg-manager.sh
@@ -6,6 +6,12 @@ NAME="${PARAM_STR_REF}"
 VERSION=""
 SUDO=""
 
+if [[ ${EUID} -ne 0 ]]; then
+  echo "Using sudo privileges to finish the process"
+
+  SUDO="sudo"
+fi
+
 check_installation () {
   local installed_version
   local required_version
@@ -31,6 +37,25 @@ check_installation () {
   fi
 }
 
+change_pnpm_store_dir_and_exit () {
+  local current_store_dir
+  local target_store_dir
+
+  current_store_dir=$(pnpm store path)
+  target_store_dir="${HOME}/.pnpm_store"
+
+  if [[ "${current_store_dir}" != "${target_store_dir}" ]]; then
+    echo "Changing the pnpm store directory"
+
+    set -x
+    pnpm config set store-dir "${target_store_dir}"
+    ${SUDO} rm -rf "${current_store_dir}"
+    set +x
+  fi
+
+  exit 0
+}
+
 if [[ "${PARAM_STR_REF}" =~ ${PKG_MANAGER_WITH_VERSION_REGEX} ]]; then
   NAME="${BASH_REMATCH[1]}"
   VERSION="${BASH_REMATCH[2]}"
@@ -39,34 +64,56 @@ fi
 echo "export CURRENT_PKG_MANAGER='${NAME}'" >> "${BASH_ENV}"
 echo "Starting to ensure ${NAME} is set for usage"
 
-if [[ ${EUID} -ne 0 ]]; then
-  echo "Using sudo privileges to finish the process"
-
-  SUDO="sudo"
-fi
-
+cd ~ || echo "Cannot navigate to home, possible version mismatch"
+  
 if [[ "${NAME}" == "npm" ]]; then
+  echo "Detected npm $(npm --version)"
+
   if [[ -n "${VERSION}" ]]; then
-    ${SUDO} npm i -g npm@"${VERSION}"
-    check_installation "${NAME}" "${VERSION}"
-  else
-    echo "Detected npm version: $(npm --version)"
+    if npm --version | grep "${VERSION}" > /dev/null 2>&1; then
+      echo "Requested version of npm is already installed"
+    else
+      echo "Requested version of npm not found, updating detected version"
+    
+      ${SUDO} npm i -g npm@"${VERSION}"
+      check_installation "${NAME}" "${VERSION}"
+    fi
+
+    exit 0
   fi
+
+  echo "Using detected version of npm"
 
   exit 0
 fi
 
 if [[ "${NAME}" == "pnpm" ]]; then
   if command -v pnpm > /dev/null 2>&1; then
-    echo "Found pnpm installation, removing it"
+    echo "Detected pnpm $(pnpm --version)"
+    
+    if [[ -z "${VERSION}" ]]; then
+      echo "Using detected version of pnpm"
+
+      change_pnpm_store_dir_and_exit
+    elif pnpm --version | grep "${VERSION}" > /dev/null 2>&1; then
+      echo "Requested vesion of pnpm is already installed"
+
+      change_pnpm_store_dir_and_exit
+    fi
+
+    echo "Requested version of pnpm not found, removing detected version"
 
     ${SUDO} rm -rf "$(pnpm store path)" > /dev/null 2>&1
     ${SUDO} rm -rf "${PNPM_HOME}" > /dev/null 2>&1
     ${SUDO} npm rm -g pnpm > /dev/null 2>&1
+  else
+    echo "Did not detect pnpm, proceeding with installation"
   fi
 
   if [[ -z "${VERSION}" ]]; then
     VERSION=$(npm view pnpm version)
+
+    echo "Version not explicitly requested, opting for ${VERSION}"
   fi
 
   ${SUDO} npm i -g pnpm@"${VERSION}"


### PR DESCRIPTION
Both npm and pnpm now default to the detected version, when the 
version is omitted. In a case where pnpm is not detected, the latest 
version will be installed.
This change also brings few minor improvements:
- Will not try to reinstall requested version if already installed
- Increase log points for easier debugging.