### PR TITLE
feat: add option to skip `install_dependencies` for `run_script`

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -112,7 +112,28 @@ jobs:
           name: Print output file
           working_directory: ~/project/sample
           command: cat results_pnpm.json
-
+  run-script-skip-install-dependencies:
+    executor: core/node
+    steps:
+      - checkout
+      - core/install_dependencies:
+          pkg_manager: pnpm
+          pkg_json_dir: ~/project/sample
+      - run:
+          name: Unset CURRENT_PKG_MANAGER env
+          command: echo "export CURRENT_PKG_MANAGER=''" >> "${BASH_ENV}"
+      - core/run_script:
+          pkg_manager: pnpm
+          pkg_json_dir: ~/project/sample
+          skip_install_dependencies: true
+          script: test --json --outputFile=results_pnpm.json
+      - run:
+          name: Verfiy install_dependencies was skipped
+          command: |
+            if [[ -n "${CURRENT_PKG_MANAGER}" ]]; then
+              echo "The install_dependencies command was not skipped"
+              exit 1
+            fi
 workflows:
   test-deploy:
     jobs:
@@ -132,6 +153,8 @@ workflows:
           filters: *filters
       - run-script-pnpm:
           filters: *filters
+      - run-script-skip-install-dependencies:
+          filters: *filters
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
@@ -148,5 +171,6 @@ workflows:
             - install-dependencies-custom-command
             - run-script-npm
             - run-script-pnpm
+            - run-script-skip-install-dependencies
           context: orb-publishing
           filters: *release-filters

--- a/src/commands/run_script.yml
+++ b/src/commands/run_script.yml
@@ -27,6 +27,12 @@ parameters:
     type: string
     default: 'v1'
     description: Change the default cache version if the cache needs to be cleared for some reason.
+  skip_install_dependencies:
+    type: boolean
+    default: false
+    description: |
+      The flag indicating whether to skip installing dependencies.
+      Useful in a case of multiple `run_script` commands inside a single job.
   script:
     type: string
     default: ''
@@ -35,15 +41,19 @@ parameters:
       manager, meaning it can contain arguments as well.
 
 steps:
-  - install_dependencies:
-      pkg_manager: <<parameters.pkg_manager>>
-      pkg_json_dir: <<parameters.pkg_json_dir>>
-      install_command: <<parameters.install_command>>
-      cache_version: <<parameters.cache_version>>
+  - unless:
+      condition: <<parameters.skip_install_dependencies>>
+      steps:
+        - install_dependencies:
+            pkg_manager: <<parameters.pkg_manager>>
+            pkg_json_dir: <<parameters.pkg_json_dir>>
+            install_command: <<parameters.install_command>>
+            cache_version: <<parameters.cache_version>>
   - run:
       name: Run "<<parameters.script>>" with "<<parameters.pkg_manager>>"
       working_directory: <<parameters.pkg_json_dir>>
       environment:
+        PARAM_STR_PKG_MANAGER: <<parameters.pkg_manager>>
         PARAM_STR_SCRIPT: <<parameters.script>>
       command: <<include(scripts/run-script.sh)>>
 

--- a/src/scripts/run-script.sh
+++ b/src/scripts/run-script.sh
@@ -3,5 +3,5 @@
 echo "Running custom script from package.json at ${PWD}"
 
 set -x
-eval "${CURRENT_PKG_MANAGER}" run "${PARAM_STR_SCRIPT}"
+eval "${PARAM_STR_PKG_MANAGER}" run "${PARAM_STR_SCRIPT}"
 set +x


### PR DESCRIPTION
The `skip_install_dependencies` flag allows running scripts without
installing dependencies first. Intended for jobs with multiple 
`run_script` commands.

Resolves feature request #33.