### PR TITLE
fix: support running script with versioned package manager

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -121,7 +121,7 @@ jobs:
     steps:
       - checkout
       - core/run_script:
-          pkg_manager: pnpm
+          pkg_manager: pnpm@latest-10
           pkg_json_dir: ~/project/sample
           script: test --json --outputFile=results_pnpm.json
       - run:

--- a/src/scripts/run-script.sh
+++ b/src/scripts/run-script.sh
@@ -2,6 +2,17 @@
 
 echo "Running custom script from package.json at ${PWD}"
 
+PKG_MANAGER=$(circleci env subst "${PARAM_STR_PKG_MANAGER}")
+PKG_MANAGER_REGEX="^(npm|pnpm)(@.+)?$"
+
+if [[ "${PKG_MANAGER}" =~ ${PKG_MANAGER_REGEX} ]]; then
+  PKG_MANAGER="${BASH_REMATCH[1]}"
+else
+  echo "Cannot run script with unsupported package manager '${PKG_MANAGER}'"
+
+  exit 1
+fi
+
 set -x
-eval "${PARAM_STR_PKG_MANAGER}" run "${PARAM_STR_SCRIPT}"
+eval "${PKG_MANAGER}" run "${PARAM_STR_SCRIPT}"
 set +x


### PR DESCRIPTION
Passing package manager with version or tag will not produce error since value is processed before usage.