### PR TITLE
fix: bypass env masking when ensuring package manager

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -72,6 +72,19 @@ jobs:
               echo "pnpm version $PNPM_LATEST_VERSION not found"
               exit 1
             fi
+  ensure-default-pkg-manager-env:
+    executor: core/node
+    steps:
+      - core/ensure_pkg_manager
+      - run:
+          name: Validate version
+          command: |
+            PNPM_NEXT_10_VERSION=$(npm view pnpm dist-tags.next-10)
+            if ! pnpm --version | grep -q "$PNPM_NEXT_10_VERSION"; then
+              echo "pnpm version $PNPM_NEXT_10_VERSION not found"
+              exit 1
+            fi
+
   install-dependencies-npm-node-18:
     executor:
       name: core/node_secrets
@@ -161,6 +174,8 @@ workflows:
           filters: *filters
       - ensure-pnpm-machine-install:
           filters: *filters
+      - ensure-default-pkg-manager-env:
+          filters: *filters
       - install-dependencies-npm-node-18:
           filters: *filters
       - install-dependencies-pnpm-node-18:
@@ -185,6 +200,7 @@ workflows:
             - ensure-pnpm-version
             - ensure-pnpm-fresh-install
             - ensure-pnpm-machine-install
+            - ensure-default-pkg-manager-env
             - install-dependencies-npm-node-18
             - install-dependencies-pnpm-node-18
             - install-dependencies-custom-command

--- a/src/commands/ensure_pkg_manager.yml
+++ b/src/commands/ensure_pkg_manager.yml
@@ -17,7 +17,10 @@ steps:
       name: Check Node.js version
       command: <<include(scripts/check-node-version.sh)>>
   - run:
-      name: Ensure package manager
+      name: Export package manager
       environment:
         PARAM_STR_REF: <<parameters.ref>>
+      command: <<include(scripts/export-pkg-manager.sh)>>
+  - run:
+      name: Ensure package manager
       command: <<include(scripts/ensure-pkg-manager.sh)>>

--- a/src/scripts/ensure-pkg-manager.sh
+++ b/src/scripts/ensure-pkg-manager.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-PARAM_STR_REF=$(circleci env subst "${PARAM_STR_REF}")
-PKG_MANAGER_WITH_VERSION_REGEX="(npm|pnpm)@(([0-9]+.?){0,2}[0-9]+|[a-z]+-?([0-9]+)?)"
-NAME="${PARAM_STR_REF}"
-VERSION=""
+NAME="${CURRENT_PKG_MANAGER}"
+VERSION="${CURRENT_PKG_MANAGER_VERSION}"
 SUDO=""
 NPM_SUDO=""
 
@@ -64,13 +62,7 @@ change_pnpm_store_dir_and_exit() {
   exit 0
 }
 
-if [[ "${PARAM_STR_REF}" =~ ${PKG_MANAGER_WITH_VERSION_REGEX} ]]; then
-  NAME="${BASH_REMATCH[1]}"
-  VERSION="${BASH_REMATCH[2]}"
-fi
-
-echo "export CURRENT_PKG_MANAGER='${NAME}'" >>"${BASH_ENV}"
-echo "Starting to ensure ${NAME} is set for usage"
+echo "Starting to ensure '${NAME}' is set for usage"
 
 cd ~ || echo "Cannot navigate to home, possible version mismatch"
 

--- a/src/scripts/export-pkg-manager.sh
+++ b/src/scripts/export-pkg-manager.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+PARAM_STR_REF=$(circleci env subst "${PARAM_STR_REF}")
+PKG_MANAGER_REGEX="^(npm|pnpm)(@(([0-9]+.?){0,2}[0-9]+|[a-z]+-?([0-9]+)?))?$"
+NAME=""
+VERSION=""
+
+if [[ "${PARAM_STR_REF}" =~ ${PKG_MANAGER_REGEX} ]]; then
+  NAME="${BASH_REMATCH[1]}"
+  VERSION="${BASH_REMATCH[3]}"
+fi
+
+if [[ -z "${NAME}" ]]; then
+  echo "Package manager '${NAME}' is not supported"
+  echo "Please specify supported package manager through parameter or environment"
+
+  exit 1
+fi
+
+echo "export CURRENT_PKG_MANAGER='${NAME}'" >>"${BASH_ENV}"
+echo "export CURRENT_PKG_MANAGER_VERSION='${VERSION}'" >>"${BASH_ENV}"


### PR DESCRIPTION
Always match provided package manager to regex in order to bypass enforced environment masking.
This logic now includes updated regex and is isolated in a separate file.