### PR TITLE
feat: fully independent commands

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -20,7 +20,7 @@ jobs:
     executor: core/node
     steps:
       - core/ensure_pkg_manager:
-          ref: npm@latest
+          pkg_manager: npm@latest
       - run:
           name: Validate version
           command: |
@@ -33,7 +33,7 @@ jobs:
     executor: core/node_secrets
     steps:
       - core/ensure_pkg_manager:
-          ref: pnpm@latest
+          pkg_manager: pnpm@latest
       - run:
           name: Validate version
           command: |
@@ -48,7 +48,7 @@ jobs:
     resource_class: medium
     steps:
       - core/ensure_pkg_manager:
-          ref: pnpm
+          pkg_manager: pnpm
       - run:
           name: Validate version
           command: |
@@ -63,7 +63,7 @@ jobs:
     steps:
       - node/install
       - core/ensure_pkg_manager:
-          ref: pnpm
+          pkg_manager: pnpm
       - run:
           name: Validate version
           command: |
@@ -77,11 +77,15 @@ jobs:
     steps:
       - core/ensure_pkg_manager
       - run:
-          name: Validate version
+          name: Validate version and metadata ownership
           command: |
             PNPM_NEXT_10_VERSION=$(npm view pnpm dist-tags.next-10)
             if ! pnpm --version | grep -q "$PNPM_NEXT_10_VERSION"; then
               echo "pnpm version $PNPM_NEXT_10_VERSION not found"
+              exit 1
+            fi
+            if [ -f /tmp/node-pkg-manager ]; then
+              echo "ensure_pkg_manager should not create package manager cache metadata"
               exit 1
             fi
 
@@ -91,10 +95,28 @@ jobs:
       tag: "18"
     steps:
       - checkout
+      - core/ensure_pkg_manager:
+          pkg_manager: npm
       - core/install_dependencies:
           pkg_manager: npm
           pkg_json_dir: ~/project/sample
           cache_version: node18_v7
+      - run:
+          name: Validate npm dependency cache cleanup
+          command: |
+            if [ -d "$HOME/.cache/pipeline-core-orb/dependency-cache" ]; then
+              echo "Expected dependency cache staging root to be removed"
+              exit 1
+            fi
+            NPM_CACHE_DIR=$(npm config get cache)
+            if [ ! -d "$NPM_CACHE_DIR" ]; then
+              echo "Expected npm cache directory to remain after staging cleanup"
+              exit 1
+            fi
+            if [ -f /tmp/node-pkg-manager ]; then
+              echo "Expected package manager cache metadata to be removed"
+              exit 1
+            fi
       - run: cd ~/project/sample && npm run build
   install-dependencies-pnpm-node-18:
     executor:
@@ -102,25 +124,97 @@ jobs:
       tag: "18.20"
     steps:
       - checkout
+      - core/ensure_pkg_manager:
+          pkg_manager: pnpm
       - core/install_dependencies:
           pkg_manager: pnpm
           pkg_json_dir: ~/project/sample
           cache_version: node18_v7
+      - run:
+          name: Validate pnpm dependency cache cleanup
+          command: |
+            if [ -d "$HOME/.cache/pipeline-core-orb/dependency-cache" ]; then
+              echo "Expected dependency cache staging root to be removed"
+              exit 1
+            fi
+            PNPM_STORE_DIR=$(pnpm store path)
+            if [ ! -d "$PNPM_STORE_DIR" ]; then
+              echo "Expected pnpm store directory to remain after staging cleanup"
+              exit 1
+            fi
+            if [ -f /tmp/node-pkg-manager ]; then
+              echo "Expected package manager cache metadata to be removed"
+              exit 1
+            fi
       - run: cd ~/project/sample && pnpm run build
   install-dependencies-custom-command:
     executor: core/node
     steps:
       - checkout
-      - core/install_dependencies:
+      - core/ensure_pkg_manager:
           pkg_manager: pnpm@10.5.1
+      - core/install_dependencies:
+          pkg_manager: pnpm
           pkg_json_dir: ~/project/sample
           install_command: pnpm install
           cache_version: v10
+      - run: cd ~/project/sample && pnpm run build
+  install-dependencies-default-pkg-manager-env:
+    executor: core/node
+    steps:
+      - checkout
+      - core/ensure_pkg_manager
+      - core/install_dependencies:
+          pkg_json_dir: ~/project/sample
+          cache_version: default_env_v1
+      - run:
+          name: Validate default package manager dependency cache cleanup
+          command: |
+            if [ -d "$HOME/.cache/pipeline-core-orb/dependency-cache" ]; then
+              echo "Expected dependency cache staging root to be removed"
+              exit 1
+            fi
+            PNPM_STORE_DIR=$(pnpm store path)
+            if [ ! -d "$PNPM_STORE_DIR" ]; then
+              echo "Expected pnpm store directory to remain after staging cleanup"
+              exit 1
+            fi
+            if [ -f /tmp/node-pkg-manager ]; then
+              echo "Expected package manager cache metadata to be removed"
+              exit 1
+            fi
+      - run: cd ~/project/sample && pnpm run build
+  install-dependencies-preinstalled-npm:
+    executor: core/node
+    steps:
+      - checkout
+      - core/install_dependencies:
+          pkg_manager: npm
+          pkg_json_dir: ~/project/sample
+          cache_version: external_preinstalled_npm_v1
       - run: cd ~/project/sample && npm run build
+  install-dependencies-externally-installed-pnpm:
+    executor: core/node
+    steps:
+      - checkout
+      - run:
+          name: Install pnpm externally
+          command: sudo npm install -g pnpm@10.5.1
+      - core/install_dependencies:
+          pkg_manager: pnpm
+          pkg_json_dir: ~/project/sample
+          cache_version: external_installed_pnpm_v1
+      - run: cd ~/project/sample && pnpm run build
+
   run-script-npm:
     executor: core/node
     steps:
       - checkout
+      - core/ensure_pkg_manager:
+          pkg_manager: npm
+      - core/install_dependencies:
+          pkg_manager: npm
+          pkg_json_dir: ~/project/sample
       - core/run_script:
           pkg_manager: npm
           pkg_json_dir: ~/project/sample
@@ -133,36 +227,59 @@ jobs:
     executor: core/node
     steps:
       - checkout
-      - core/run_script:
+      - core/ensure_pkg_manager:
           pkg_manager: pnpm@latest-10
+      - core/install_dependencies:
+          pkg_manager: pnpm
+          pkg_json_dir: ~/project/sample
+      - core/run_script:
+          pkg_manager: pnpm
           pkg_json_dir: ~/project/sample
           script: test --json --outputFile=results_pnpm.json
       - run:
           name: Print output file
           working_directory: ~/project/sample
           command: cat results_pnpm.json
-  run-script-skip-install-dependencies:
+  run-script-default-pkg-manager-env:
     executor: core/node
     steps:
       - checkout
+      - core/ensure_pkg_manager
       - core/install_dependencies:
-          pkg_manager: pnpm
           pkg_json_dir: ~/project/sample
+      - core/run_script:
+          pkg_json_dir: ~/project/sample
+          script: test --json --outputFile=results_pnpm_default.json
       - run:
-          name: Unset CURRENT_PKG_MANAGER env
-          command: echo "export CURRENT_PKG_MANAGER=''" >> "${BASH_ENV}"
+          name: Validate run_script package manager metadata ownership
+          command: |
+            if [ -f /tmp/node-pkg-manager ]; then
+              echo "run_script should not create package manager cache metadata"
+              exit 1
+            fi
+      - run:
+          name: Print output file
+          working_directory: ~/project/sample
+          command: cat results_pnpm_default.json
+  run-script-externally-prepared-pnpm:
+    executor: core/node
+    steps:
+      - checkout
+      - run:
+          name: Install pnpm externally
+          command: sudo npm install -g pnpm@10.5.1
+      - run:
+          name: Install dependencies externally
+          command: pnpm install --frozen-lockfile
+          working_directory: ~/project/sample
       - core/run_script:
           pkg_manager: pnpm
           pkg_json_dir: ~/project/sample
-          skip_install_dependencies: true
-          script: test --json --outputFile=results_pnpm.json
+          script: test --json --outputFile=results_external_pnpm.json
       - run:
-          name: Verfiy install_dependencies was skipped
-          command: |
-            if [[ -n "${CURRENT_PKG_MANAGER}" ]]; then
-              echo "The install_dependencies command was not skipped"
-              exit 1
-            fi
+          name: Print output file
+          working_directory: ~/project/sample
+          command: cat results_external_pnpm.json
 workflows:
   test-deploy:
     jobs:
@@ -182,11 +299,19 @@ workflows:
           filters: *filters
       - install-dependencies-custom-command:
           filters: *filters
+      - install-dependencies-default-pkg-manager-env:
+          filters: *filters
+      - install-dependencies-preinstalled-npm:
+          filters: *filters
+      - install-dependencies-externally-installed-pnpm:
+          filters: *filters
       - run-script-npm:
           filters: *filters
       - run-script-pnpm:
           filters: *filters
-      - run-script-skip-install-dependencies:
+      - run-script-default-pkg-manager-env:
+          filters: *filters
+      - run-script-externally-prepared-pnpm:
           filters: *filters
       - orb-tools/pack:
           filters: *release-filters
@@ -204,8 +329,12 @@ workflows:
             - install-dependencies-npm-node-18
             - install-dependencies-pnpm-node-18
             - install-dependencies-custom-command
+            - install-dependencies-default-pkg-manager-env
+            - install-dependencies-preinstalled-npm
+            - install-dependencies-externally-installed-pnpm
             - run-script-npm
             - run-script-pnpm
-            - run-script-skip-install-dependencies
+            - run-script-default-pkg-manager-env
+            - run-script-externally-prepared-pnpm
           context: orb-publishing
           filters: *release-filters

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 description: >
-  Core commands for Node.js projects, install dependencies with caching by default and run
-  scripts, using npm or pnpm package manager. Tailored for use within Studion pipelines.
+  Core commands for Node.js projects: ensure npm or pnpm package managers, install
+  dependencies with caching, and run package.json scripts. Tailored for use within Studion pipelines.
 
 display:
   home_url: "https://circleci.com/developer/orbs/orb/studion/core"

--- a/src/commands/ensure_pkg_manager.yml
+++ b/src/commands/ensure_pkg_manager.yml
@@ -1,15 +1,16 @@
 description: >
-  Ensure required package manager is in place, optionally specifing the exact version.
+  Ensure the requested package manager is installed and configured, optionally specifying the exact version.
   Requires execution environment with Node.js >= 18.20 pre-installed.
 
 parameters:
-  ref:
+  pkg_manager:
     type: string
-    default: ${DEFAULT_PKG_MANAGER}
+    default: ""
     description: |
-      Choose Node.js package manager to use. Supports npm and pnpm.
+      Choose Node.js package manager to ensure. Supports npm and pnpm.
       The package manager must follow the format <name>[@<version|tag>].
-      Omitting the version implies
+      When omitted, the DEFAULT_PKG_MANAGER environment variable is used at runtime.
+      Omitting the version/tag implies
       (for npm) use the version that comes with the target Node.js environment,
       (for pnpm) use the existing version if found, otherwise use the latest version.
 steps:
@@ -17,9 +18,9 @@ steps:
       name: Check Node.js version
       command: <<include(scripts/check-node-version.sh)>>
   - run:
-      name: Export package manager
+      name: Resolve package manager
       environment:
-        PARAM_STR_REF: <<parameters.ref>>
+        PARAM_STR_PKG_MANAGER: <<parameters.pkg_manager>>
       command: <<include(scripts/export-pkg-manager.sh)>>
   - run:
       name: Ensure package manager

--- a/src/commands/install_dependencies.yml
+++ b/src/commands/install_dependencies.yml
@@ -1,16 +1,17 @@
 description: >
-  Install dependencies with caching, optionally choose a package manager.
+  Install dependencies with manager-specific caching using an already available package manager.
   Requires execution environment with Node.js >= 18.20 pre-installed.
 
 parameters:
   pkg_manager:
     type: string
-    default: ${DEFAULT_PKG_MANAGER}
+    default: ""
     description: |
       Choose Node.js package manager to use. Supports npm and pnpm.
-      The package manager must follow the format <name>[@<version|tag>].
-      Omitting the version implies that the npm version is determined by the target Node.js environment,
-      while pnpm will default to the latest version.
+      The package manager may follow the format <name>[@<version|tag>], but install execution uses only the name.
+      When omitted, the DEFAULT_PKG_MANAGER environment variable is used at runtime.
+      Dependency cache restore/save behavior is based on the resolved package manager.
+      This command does not install or update package managers; use ensure_pkg_manager before this command when needed.
   pkg_json_dir:
     type: string
     default: "."
@@ -29,44 +30,57 @@ parameters:
     description: Change the default cache version if the cache needs to be cleared for some reason.
 
 steps:
-  - ensure_pkg_manager:
-      ref: <<parameters.pkg_manager>>
+  - run:
+      name: Check Node.js version
+      command: <<include(scripts/check-node-version.sh)>>
+  - run:
+      name: Resolve package manager
+      environment:
+        PARAM_STR_PKG_MANAGER: <<parameters.pkg_manager>>
+      command: <<include(scripts/export-pkg-manager.sh)>>
+  - run:
+      name: Validate package manager
+      command: <<include(scripts/validate-pkg-manager.sh)>>
   - run:
       name: Check for package.json
       working_directory: <<parameters.pkg_json_dir>>
       command: <<include(scripts/check-pkg-json.sh)>>
+  - run:
+      name: Write package manager cache metadata
+      command: <<include(scripts/write-pkg-manager-cache-metadata.sh)>>
   - run:
       name: Process lockfile
       working_directory: <<parameters.pkg_json_dir>>
       command: <<include(scripts/process-lockfile.sh)>>
   - restore_cache:
       keys:
-        - node-{{ arch }}-<<parameters.cache_version>>-{{ .Branch }}-{{ checksum "/tmp/node-lockfile" }}
-        - node-{{ arch }}-<<parameters.cache_version>>-{{ .Branch }}-
-        - node-{{ arch }}-<<parameters.cache_version>>-
+        - node-{{ arch }}-<<parameters.cache_version>>-{{ checksum "/tmp/node-pkg-manager" }}-{{ checksum "/tmp/node-lockfile" }}
+        - node-{{ arch }}-<<parameters.cache_version>>-{{ checksum "/tmp/node-pkg-manager" }}-
+  - run:
+      name: Restore dependency cache
+      environment:
+        PARAM_STR_CACHE_MODE: restore
+      command: <<include(scripts/manage-dependency-cache.sh)>>
   - run:
       name: Install dependencies
       working_directory: <<parameters.pkg_json_dir>>
       environment:
         PARAM_STR_INSTALL_COMMAND: <<parameters.install_command>>
       command: <<include(scripts/install-dependencies.sh)>>
-  - when:
-      condition:
-        matches: { pattern: "^npm(.{0,})?$", value: <<parameters.pkg_manager>> }
-      steps:
-        - save_cache:
-            key: node-{{ arch }}-<<parameters.cache_version>>-{{ .Branch }}-{{ checksum "/tmp/node-lockfile" }}
-            paths:
-              - ~/.npm
-  - when:
-      condition:
-        matches:
-          { pattern: "^pnpm(.{0,})?$", value: <<parameters.pkg_manager>> }
-      steps:
-        - save_cache:
-            key: node-{{ arch }}-<<parameters.cache_version>>-{{ .Branch }}-{{ checksum "/tmp/node-lockfile" }}
-            paths:
-              - ~/.pnpm-store
   - run:
-      name: Remove temporary lockfile
-      command: rm -f /tmp/node-lockfile
+      name: Prepare dependency cache
+      environment:
+        PARAM_STR_CACHE_MODE: prepare
+      command: <<include(scripts/manage-dependency-cache.sh)>>
+  - save_cache:
+      key: node-{{ arch }}-<<parameters.cache_version>>-{{ checksum "/tmp/node-pkg-manager" }}-{{ checksum "/tmp/node-lockfile" }}
+      paths:
+        - ~/.cache/pipeline-core-orb/dependency-cache
+  - run:
+      name: Remove dependency cache staging
+      environment:
+        PARAM_STR_CACHE_MODE: cleanup
+      command: <<include(scripts/manage-dependency-cache.sh)>>
+  - run:
+      name: Remove temporary dependency metadata
+      command: rm -f /tmp/node-lockfile /tmp/node-pkg-manager

--- a/src/commands/run_script.yml
+++ b/src/commands/run_script.yml
@@ -1,43 +1,27 @@
 description: >
-  Simple command that enables running scripts defined within package.json.
+  Run scripts defined within package.json using an already available package manager.
   Requires execution environment with Node.js >= 18.20 pre-installed.
 
 parameters:
   pkg_manager:
     type: string
-    default: ${DEFAULT_PKG_MANAGER}
+    default: ""
     description: |
       Choose Node.js package manager to use. Supports npm and pnpm.
-      The package manager must follow the format <name>[@<version|tag>].
-      Omitting the version implies that the npm version is determined by the target Node.js environment,
-      while pnpm will default to the latest version.
+      The package manager may follow the format <name>[@<version|tag>], but script execution uses only the name.
+      When omitted, the DEFAULT_PKG_MANAGER environment variable is used at runtime.
+      This command does not install dependencies; use install_dependencies before this command when needed.
   pkg_json_dir:
     type: string
     default: "."
     description: >
       Path to the directory containing package.json file.
       Not needed when package.json is in the root.
-  install_command:
-    type: string
-    default: ""
-    description: >
-      Custom command to install dependencies. Useful when default commands,
-      "npm ci" or "pnpm i --frozen-lockfile", are unsuitable.
-  cache_version:
-    type: string
-    default: "v1"
-    description: Change the default cache version if the cache needs to be cleared for some reason.
-  skip_install_dependencies:
-    type: boolean
-    default: false
-    description: |
-      The flag indicating whether to skip installing dependencies.
-      Useful in a case of multiple `run_script` commands inside a single job.
   script:
     type: string
     default: ""
     description: >
-      Name of the script to execute. Passed as is to the run command of choosen pacakge
+      Name of the script to execute. Passed as is to the run command of chosen package
       manager, meaning it can contain arguments as well.
   no_output_timeout:
     type: string
@@ -47,19 +31,25 @@ parameters:
       The string is a decimal with unit suffix, such as "20m", "1.25h", "5s".
 
 steps:
-  - unless:
-      condition: <<parameters.skip_install_dependencies>>
-      steps:
-        - install_dependencies:
-            pkg_manager: <<parameters.pkg_manager>>
-            pkg_json_dir: <<parameters.pkg_json_dir>>
-            install_command: <<parameters.install_command>>
-            cache_version: <<parameters.cache_version>>
   - run:
-      name: Run "<<parameters.script>>" with "<<parameters.pkg_manager>>"
-      working_directory: <<parameters.pkg_json_dir>>
+      name: Check Node.js version
+      command: <<include(scripts/check-node-version.sh)>>
+  - run:
+      name: Resolve package manager
       environment:
         PARAM_STR_PKG_MANAGER: <<parameters.pkg_manager>>
+      command: <<include(scripts/export-pkg-manager.sh)>>
+  - run:
+      name: Validate package manager
+      command: <<include(scripts/validate-pkg-manager.sh)>>
+  - run:
+      name: Check for package.json
+      working_directory: <<parameters.pkg_json_dir>>
+      command: <<include(scripts/check-pkg-json.sh)>>
+  - run:
+      name: Run package.json script "<<parameters.script>>"
+      working_directory: <<parameters.pkg_json_dir>>
+      environment:
         PARAM_STR_SCRIPT: <<parameters.script>>
       command: <<include(scripts/run-script.sh)>>
       no_output_timeout: <<parameters.no_output_timeout>>

--- a/src/examples/npm_run.yml
+++ b/src/examples/npm_run.yml
@@ -1,6 +1,6 @@
 description: |
-  Run any script defined inside a "package.json" using the targeted package manager.
-  Before running the specified script, the command will fetch the code and install dependencies.
+  Run any script defined inside a package.json using an already available package manager.
+  Install dependencies explicitly before running the specified script when the project requires them.
 
 usage:
   version: 2.1
@@ -11,6 +11,10 @@ usage:
       executor: core/node
       steps:
         - checkout
+        - core/ensure_pkg_manager:
+            pkg_manager: npm
+        - core/install_dependencies:
+            pkg_manager: npm
         - core/run_script:
             pkg_manager: npm
             script: test

--- a/src/examples/pnpm_ensure.yml
+++ b/src/examples/pnpm_ensure.yml
@@ -12,7 +12,7 @@ usage:
       executor: core/node
       steps:
         - core/ensure_pkg_manager:
-            ref: pnpm@9.0.1
+            pkg_manager: pnpm@9.0.1
         - run: pnpm audit --prod
   workflows:
     audit_deps:

--- a/src/examples/pnpm_install.yml
+++ b/src/examples/pnpm_install.yml
@@ -1,6 +1,6 @@
 description: |
-  By default, the "install_dependencies" command respects automated environments
-  and installs dependencies consistently and predictably.
+  Install dependencies with caching using a package manager that has already been ensured.
+  Use ensure_pkg_manager before this command when the execution environment does not already provide the desired package manager.
   There is an option to override the install command, package manager, and root directory.
 
 usage:
@@ -15,6 +15,8 @@ usage:
         resource_class: xlarge
       steps:
         - checkout
+        - core/ensure_pkg_manager:
+            pkg_manager: pnpm@9.0.1
         - core/install_dependencies:
             pkg_manager: pnpm
             pkg_json_dir: ~/workspace/project

--- a/src/scripts/check-node-version.sh
+++ b/src/scripts/check-node-version.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js not detected"
+  echo "Execution environment with Node.js pre-installed is required!"
+
+  exit 1
+fi
+
 NODE_VERSION_REGEX="v([0-9]+).([0-9]+).([0-9]+)"
 NODE_VERSION=$(node -v)
 MAJOR=""

--- a/src/scripts/ensure-pkg-manager.sh
+++ b/src/scripts/ensure-pkg-manager.sh
@@ -3,18 +3,18 @@
 NAME="${CURRENT_PKG_MANAGER}"
 VERSION="${CURRENT_PKG_MANAGER_VERSION}"
 SUDO=""
-NPM_SUDO=""
+NPM_I_SUDO=""
 
 if [[ ${EUID} -ne 0 ]]; then
-  echo "Using sudo privileges, excluding npm commands, to finish the process"
+  echo "Using sudo privileges, excluding npm install commands, to finish the process"
 
   SUDO="sudo"
 
   if [[ ! -w "$(npm root -g)" ]]; then
     echo "Missing write permission for global node_modules directory"
-    echo "Using sudo privileges for npm commands as well"
+    echo "Using sudo privileges for npm install commands as well"
 
-    NPM_SUDO="sudo"
+    NPM_I_SUDO="sudo"
   fi
 fi
 
@@ -48,7 +48,7 @@ change_pnpm_store_dir_and_exit() {
   local target_store_dir
 
   current_store_dir=$(pnpm store path)
-  target_store_dir="${HOME}/.pnpm_store"
+  target_store_dir="${HOME}/.pnpm-store"
 
   if [[ "${current_store_dir}" != "${target_store_dir}" ]]; then
     echo "Changing the pnpm store directory"
@@ -75,7 +75,7 @@ if [[ "${NAME}" == "npm" ]]; then
     else
       echo "Requested version of npm not found, updating detected version"
 
-      ${NPM_SUDO} npm i -g npm@"${VERSION}"
+      ${NPM_I_SUDO} npm i -g npm@"${VERSION}"
       check_installation "${NAME}" "${VERSION}"
     fi
 
@@ -96,7 +96,7 @@ if [[ "${NAME}" == "pnpm" ]]; then
 
       change_pnpm_store_dir_and_exit
     elif pnpm --version | grep "${VERSION}" >/dev/null 2>&1; then
-      echo "Requested vesion of pnpm is already installed"
+      echo "Requested version of pnpm is already installed"
 
       change_pnpm_store_dir_and_exit
     fi
@@ -105,7 +105,7 @@ if [[ "${NAME}" == "pnpm" ]]; then
 
     ${SUDO} rm -rf "$(pnpm store path)" >/dev/null 2>&1
     ${SUDO} rm -rf "${PNPM_HOME}" >/dev/null 2>&1
-    ${NPM_SUDO} npm rm -g pnpm >/dev/null 2>&1
+    ${SUDO} npm rm -g pnpm >/dev/null 2>&1
   else
     echo "Did not detect pnpm, proceeding with installation"
   fi
@@ -116,7 +116,7 @@ if [[ "${NAME}" == "pnpm" ]]; then
     echo "Version not explicitly requested, opting for ${VERSION}"
   fi
 
-  ${NPM_SUDO} npm i -g pnpm@"${VERSION}"
+  ${NPM_I_SUDO} npm i -g pnpm@"${VERSION}"
   check_installation "${NAME}" "${VERSION}"
 
   echo "Setting ~/.pnpm-store as the store directory"

--- a/src/scripts/export-pkg-manager.sh
+++ b/src/scripts/export-pkg-manager.sh
@@ -1,20 +1,26 @@
 #!/bin/bash
 
-PARAM_STR_REF=$(circleci env subst "${PARAM_STR_REF}")
-PKG_MANAGER_REGEX="^(npm|pnpm)(@(([0-9]+.?){0,2}[0-9]+|[a-z]+-?([0-9]+)?))?$"
+PKG_MANAGER_REF="${PARAM_STR_PKG_MANAGER:-${DEFAULT_PKG_MANAGER}}"
+PKG_MANAGER_REGEX="^(npm|pnpm)(@(([0-9]+\.?){0,2}[0-9]+|[a-z]+-?([0-9]+)?))?$"
 NAME=""
 VERSION=""
 
-if [[ "${PARAM_STR_REF}" =~ ${PKG_MANAGER_REGEX} ]]; then
+if [[ "${PKG_MANAGER_REF}" =~ ${PKG_MANAGER_REGEX} ]]; then
   NAME="${BASH_REMATCH[1]}"
   VERSION="${BASH_REMATCH[3]}"
 fi
 
 if [[ -z "${NAME}" ]]; then
-  echo "Package manager '${NAME}' is not supported"
-  echo "Please specify supported package manager through parameter or environment"
+  echo "Package manager '${PKG_MANAGER_REF}' is not supported"
+  echo "Please specify supported package manager through the pkg_manager parameter or DEFAULT_PKG_MANAGER environment"
 
   exit 1
+fi
+
+echo "Resolved package manager: ${NAME}"
+
+if [[ -n "${VERSION}" ]]; then
+  echo "Resolved package manager version/tag: ${VERSION}"
 fi
 
 echo "export CURRENT_PKG_MANAGER='${NAME}'" >>"${BASH_ENV}"

--- a/src/scripts/install-dependencies.sh
+++ b/src/scripts/install-dependencies.sh
@@ -5,7 +5,10 @@ if [[ -n "${PARAM_STR_INSTALL_COMMAND}" ]]; then
 
   set -x
   eval "${PARAM_STR_INSTALL_COMMAND}"
+  status=$?
   set +x
+
+  exit "${status}"
 elif [[ "${CURRENT_PKG_MANAGER}" == "npm" ]]; then
   echo "Running npm clean install"
 
@@ -14,4 +17,9 @@ elif [[ "${CURRENT_PKG_MANAGER}" == "pnpm" ]]; then
   echo "Running pnpm install with frozen lockfile"
 
   pnpm i --frozen-lockfile
+else
+  # This should not happen, but just to be on the safe side
+  echo "Cannot install dependencies with unsupported package manager '${CURRENT_PKG_MANAGER}'"
+
+  exit 1
 fi

--- a/src/scripts/manage-dependency-cache.sh
+++ b/src/scripts/manage-dependency-cache.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+CACHE_MODE="${PARAM_STR_CACHE_MODE}"
+CACHE_ROOT="${HOME}/.cache/pipeline-core-orb/dependency-cache"
+CACHE_PATH=""
+STAGED_CACHE_DIR=""
+
+validate_cache_mode() {
+  if [[ -z "${CACHE_MODE}" ]]; then
+    echo "Dependency cache mode was not provided"
+    echo "Set PARAM_STR_CACHE_MODE to one of: restore, prepare, cleanup"
+
+    exit 1
+  fi
+
+  if [[ "${CACHE_MODE}" != "restore" && "${CACHE_MODE}" != "prepare" && "${CACHE_MODE}" != "cleanup" ]]; then
+    echo "Unsupported dependency cache mode '${CACHE_MODE}'"
+    echo "Set PARAM_STR_CACHE_MODE to one of: restore, prepare, cleanup"
+
+    exit 1
+  fi
+}
+
+resolve_cache_path() {
+  if [[ -z "${CURRENT_PKG_MANAGER:-}" ]]; then
+    echo "Package manager was not resolved"
+    echo "Cannot ${CACHE_MODE} dependency cache without CURRENT_PKG_MANAGER"
+
+    exit 1
+  fi
+
+  if [[ "${CURRENT_PKG_MANAGER}" == "npm" ]]; then
+    CACHE_PATH=$(npm config get cache)
+  elif [[ "${CURRENT_PKG_MANAGER}" == "pnpm" ]]; then
+    CACHE_PATH=$(pnpm store path)
+  else
+    echo "Cannot ${CACHE_MODE} dependency cache for unsupported package manager '${CURRENT_PKG_MANAGER}'"
+
+    exit 1
+  fi
+
+  STAGED_CACHE_DIR="${CACHE_ROOT}/${CURRENT_PKG_MANAGER}"
+}
+
+is_empty_dir() {
+  [[ ! -d "$1" || -z "$(ls -A "$1")" ]]
+}
+
+restore_cache() {
+  echo "Restoring dependency cache for ${CURRENT_PKG_MANAGER}"
+  echo "Dependency cache staging root: ${CACHE_ROOT}"
+  echo "Dependency cache staging path: ${STAGED_CACHE_DIR}"
+  echo "Dependency cache target: ${CACHE_PATH}"
+
+  mkdir -p "${CACHE_PATH}"
+
+  if [[ ! -d "${STAGED_CACHE_DIR}" ]]; then
+    echo "No staged ${CURRENT_PKG_MANAGER} cache found; continuing without restored dependency cache"
+
+    exit 0
+  fi
+
+  if is_empty_dir "${STAGED_CACHE_DIR}"; then
+    echo "Staged ${CURRENT_PKG_MANAGER} cache is empty; continuing without restored dependency cache"
+
+    exit 0
+  fi
+
+  echo "Copying staged ${CURRENT_PKG_MANAGER} cache into package manager cache path"
+  cp -a "${STAGED_CACHE_DIR}/." "${CACHE_PATH}/"
+}
+
+prepare_cache() {
+  echo "Preparing dependency cache for ${CURRENT_PKG_MANAGER}"
+  echo "Dependency cache source: ${CACHE_PATH}"
+  echo "Dependency cache staging root: ${CACHE_ROOT}"
+  echo "Dependency cache staging path: ${STAGED_CACHE_DIR}"
+
+  rm -rf "${CACHE_ROOT}"
+  mkdir -p "${STAGED_CACHE_DIR}"
+
+  if [[ ! -d "${CACHE_PATH}" ]]; then
+    echo "Dependency cache source does not exist; saving empty staged cache"
+
+    exit 0
+  fi
+
+  if is_empty_dir "${CACHE_PATH}"; then
+    echo "Dependency cache source is empty; saving empty staged cache"
+
+    exit 0
+  fi
+
+  echo "Copying ${CURRENT_PKG_MANAGER} cache into staging path"
+  cp -a "${CACHE_PATH}/." "${STAGED_CACHE_DIR}/"
+}
+
+cleanup_cache() {
+  echo "Removing dependency cache staging root: ${CACHE_ROOT}"
+  rm -rf "${CACHE_ROOT}"
+}
+
+validate_cache_mode
+
+if [[ "${CACHE_MODE}" == "cleanup" ]]; then
+  cleanup_cache
+
+  exit 0
+fi
+
+resolve_cache_path
+
+if [[ "${CACHE_MODE}" == "restore" ]]; then
+  restore_cache
+elif [[ "${CACHE_MODE}" == "prepare" ]]; then
+  prepare_cache
+fi

--- a/src/scripts/process-lockfile.sh
+++ b/src/scripts/process-lockfile.sh
@@ -9,7 +9,7 @@ if [ -f "package-lock.json" ] && [[ "${CURRENT_PKG_MANAGER}" == "npm" ]]; then
 
   exit 0
 elif [ -f "pnpm-lock.yaml" ] && [[ "${CURRENT_PKG_MANAGER}" == "pnpm" ]]; then
-  echo "Found pnpm-lock.ymal, assuming lockfile"
+  echo "Found pnpm-lock.yaml, assuming lockfile"
 
   cp pnpm-lock.yaml "${DEST_FILE}"
 

--- a/src/scripts/run-script.sh
+++ b/src/scripts/run-script.sh
@@ -1,18 +1,14 @@
 #!/bin/bash
 
-echo "Running custom script from package.json at ${PWD}"
+echo "Running package.json script at ${PWD}"
 
-PKG_MANAGER=$(circleci env subst "${PARAM_STR_PKG_MANAGER}")
-PKG_MANAGER_REGEX="^(npm|pnpm)(@.+)?$"
-
-if [[ "${PKG_MANAGER}" =~ ${PKG_MANAGER_REGEX} ]]; then
-  PKG_MANAGER="${BASH_REMATCH[1]}"
+if [[ "${CURRENT_PKG_MANAGER}" == "npm" ]]; then
+  eval npm run "${PARAM_STR_SCRIPT}"
+elif [[ "${CURRENT_PKG_MANAGER}" == "pnpm" ]]; then
+  eval pnpm run "${PARAM_STR_SCRIPT}"
 else
-  echo "Cannot run script with unsupported package manager '${PKG_MANAGER}'"
+  # This should not happen, but just to be on the safe side
+  echo "Cannot run script with unsupported package manager '${CURRENT_PKG_MANAGER}'"
 
   exit 1
 fi
-
-set -x
-eval "${PKG_MANAGER}" run "${PARAM_STR_SCRIPT}"
-set +x

--- a/src/scripts/validate-pkg-manager.sh
+++ b/src/scripts/validate-pkg-manager.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [[ -z "${CURRENT_PKG_MANAGER}" ]]; then
+  echo "Package manager was not resolved"
+  echo "Please resolve it with the pkg_manager parameter or DEFAULT_PKG_MANAGER environment variable"
+
+  exit 1
+fi
+
+if ! command -v "${CURRENT_PKG_MANAGER}" >/dev/null 2>&1; then
+  echo "Package manager '${CURRENT_PKG_MANAGER}' is not available"
+  echo "Run ensure_pkg_manager before this command or use an execution environment that already includes ${CURRENT_PKG_MANAGER}"
+
+  exit 1
+fi
+
+echo "Using ${CURRENT_PKG_MANAGER} $(${CURRENT_PKG_MANAGER} --version)"

--- a/src/scripts/write-pkg-manager-cache-metadata.sh
+++ b/src/scripts/write-pkg-manager-cache-metadata.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+DEST_FILE="/tmp/node-pkg-manager"
+
+if [[ -z "${CURRENT_PKG_MANAGER}" ]]; then
+  echo "Package manager was not resolved"
+  echo "Cannot write package manager cache metadata without CURRENT_PKG_MANAGER"
+
+  exit 1
+fi
+
+if [[ "${CURRENT_PKG_MANAGER}" != "npm" && "${CURRENT_PKG_MANAGER}" != "pnpm" ]]; then
+  echo "Cannot write package manager cache metadata for unsupported package manager '${CURRENT_PKG_MANAGER}'"
+
+  exit 1
+fi
+
+echo "Writing package manager cache metadata: ${CURRENT_PKG_MANAGER}"
+echo "${CURRENT_PKG_MANAGER}" >|"${DEST_FILE}"


### PR DESCRIPTION
- All available orb commands, `ensure_pkg_manager`, `install_dependencies`, and `run_script`, are now fully independent. In other words, you can use `run_script` without it internally calling `ensure_pkg_manager` and `install_dependencies`.
- This removes hidden side effects, makes CI workflows easier to reason about, and aligns each command name with the work it performs.
- For the consistency reasons `ensure_pkg_manager` parameter `ref` is renamed to `pkg_manager`.
- The `${DEFAULT_PKG_MANAGER}` is no longer used as parameter default, but rather resolved at the runtime.
- Dependency caching is update to: no longer include branch name in the cache key, and use unified staging cache strategy.