### PR TITLE
feat: add workspace support to `run_script` command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -218,7 +218,8 @@ jobs:
       - core/run_script:
           pkg_manager: npm
           pkg_json_dir: ~/project/sample
-          script: test -- --json --outputFile=results_npm.json
+          script: test
+          script_args: --json --outputFile=results_npm.json
       - run:
           name: Print output file
           working_directory: ~/project/sample
@@ -235,7 +236,8 @@ jobs:
       - core/run_script:
           pkg_manager: pnpm
           pkg_json_dir: ~/project/sample
-          script: test --json --outputFile=results_pnpm.json
+          script: test
+          script_args: --json --outputFile=results_pnpm.json
       - run:
           name: Print output file
           working_directory: ~/project/sample
@@ -249,7 +251,8 @@ jobs:
           pkg_json_dir: ~/project/sample
       - core/run_script:
           pkg_json_dir: ~/project/sample
-          script: test --json --outputFile=results_pnpm_default.json
+          script: test
+          script_args: --json --outputFile=results_pnpm_default.json
       - run:
           name: Validate run_script package manager metadata ownership
           command: |
@@ -275,11 +278,58 @@ jobs:
       - core/run_script:
           pkg_manager: pnpm
           pkg_json_dir: ~/project/sample
-          script: test --json --outputFile=results_external_pnpm.json
+          script: test
+          script_args: --json --outputFile=results_external_pnpm.json
       - run:
           name: Print output file
           working_directory: ~/project/sample
           command: cat results_external_pnpm.json
+  run-script-npm-workspace:
+    executor: core/node
+    steps:
+      - checkout
+      - core/run_script:
+          pkg_manager: npm
+          pkg_json_dir: ~/project/sample/workspace
+          script: workspace-test
+          script_args: workspace-result-npm.txt npm workspace
+          run_options: --workspace=workspace-app
+      - run:
+          name: Validate npm workspace script output
+          working_directory: ~/project/sample/workspace/packages/app
+          command: |
+            if [ "$(cat workspace-result-npm.txt)" != "npm|workspace" ]; then
+              echo "Unexpected npm workspace script output"
+              exit 1
+            fi
+      - run:
+          name: Clean npm workspace script output
+          working_directory: ~/project/sample/workspace/packages/app
+          command: rm -f workspace-result-npm.txt
+  run-script-pnpm-workspace:
+    executor: core/node
+    steps:
+      - checkout
+      - core/ensure_pkg_manager:
+          pkg_manager: pnpm
+      - core/run_script:
+          pkg_manager: pnpm
+          pkg_json_dir: ~/project/sample/workspace
+          script: workspace-test
+          script_args: workspace-result-pnpm.txt pnpm workspace
+          run_options: --filter=workspace-app
+      - run:
+          name: Validate pnpm workspace script output
+          working_directory: ~/project/sample/workspace/packages/app
+          command: |
+            if [ "$(cat workspace-result-pnpm.txt)" != "pnpm|workspace" ]; then
+              echo "Unexpected pnpm workspace script output"
+              exit 1
+            fi
+      - run:
+          name: Clean pnpm workspace script output
+          working_directory: ~/project/sample/workspace/packages/app
+          command: rm -f workspace-result-pnpm.txt
 workflows:
   test-deploy:
     jobs:
@@ -313,6 +363,10 @@ workflows:
           filters: *filters
       - run-script-externally-prepared-pnpm:
           filters: *filters
+      - run-script-npm-workspace:
+          filters: *filters
+      - run-script-pnpm-workspace:
+          filters: *filters
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
@@ -336,5 +390,7 @@ workflows:
             - run-script-pnpm
             - run-script-default-pkg-manager-env
             - run-script-externally-prepared-pnpm
+            - run-script-npm-workspace
+            - run-script-pnpm-workspace
           context: orb-publishing
           filters: *release-filters

--- a/sample/workspace/package.json
+++ b/sample/workspace/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "workspace-sample",
+  "version": "0.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/sample/workspace/packages/app/package.json
+++ b/sample/workspace/packages/app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "workspace-app",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "workspace-test": "node workspace-test.js"
+  }
+}

--- a/sample/workspace/packages/app/workspace-test.js
+++ b/sample/workspace/packages/app/workspace-test.js
@@ -1,0 +1,11 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const scriptArgs = process.argv.slice(2).filter((arg) => arg !== "--");
+const [outputFile, ...args] = scriptArgs;
+
+if (!outputFile) {
+  throw new Error("Missing output file argument");
+}
+
+writeFileSync(resolve(process.cwd(), outputFile), args.join("|"));

--- a/sample/workspace/pnpm-workspace.yaml
+++ b/sample/workspace/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"

--- a/src/commands/run_script.yml
+++ b/src/commands/run_script.yml
@@ -1,5 +1,6 @@
 description: >
   Run scripts defined within package.json using an already available package manager.
+  Supports package manager specific run options, including npm and pnpm workspace selectors.
   Requires execution environment with Node.js >= 18.20 pre-installed.
 
 parameters:
@@ -15,14 +16,29 @@ parameters:
     type: string
     default: "."
     description: >
-      Path to the directory containing package.json file.
+      Path to the directory containing package.json file where the package manager should execute.
+      When using workspace selectors through run_options, this is typically the workspace root.
       Not needed when package.json is in the root.
   script:
     type: string
+    description: >
+      Name of the script to execute. Must contain only the package.json script name;
+      use run_options for package manager options and script_args for arguments passed to the script.
+  script_args:
+    type: string
     default: ""
     description: >
-      Name of the script to execute. Passed as is to the run command of chosen package
-      manager, meaning it can contain arguments as well.
+      Arguments passed to the package.json script. For npm, arguments are passed after an
+      automatically inserted -- separator. For pnpm, arguments are passed directly after
+      the script name; include -- explicitly when the script itself needs that separator.
+      Values are split on whitespace into command arguments.
+  run_options:
+    type: string
+    default: ""
+    description: >
+      Package manager specific options for the run command, including workspace selectors.
+      For npm these options are placed after the script name. For pnpm these options are placed before run.
+      Values are split on whitespace into command arguments.
   no_output_timeout:
     type: string
     default: "10m"
@@ -51,5 +67,7 @@ steps:
       working_directory: <<parameters.pkg_json_dir>>
       environment:
         PARAM_STR_SCRIPT: <<parameters.script>>
+        PARAM_STR_SCRIPT_ARGS: <<parameters.script_args>>
+        PARAM_STR_RUN_OPTIONS: <<parameters.run_options>>
       command: <<include(scripts/run-script.sh)>>
       no_output_timeout: <<parameters.no_output_timeout>>

--- a/src/examples/npm_run.yml
+++ b/src/examples/npm_run.yml
@@ -1,6 +1,7 @@
 description: |
   Run any script defined inside a package.json using an already available package manager.
   Install dependencies explicitly before running the specified script when the project requires them.
+  Use run_options for package manager specific options, including workspace selectors, and script_args for arguments passed after --.
 
 usage:
   version: 2.1
@@ -18,7 +19,23 @@ usage:
         - core/run_script:
             pkg_manager: npm
             script: test
+            script_args: --json --outputFile=results.json
+    workspace_test:
+      executor: core/node
+      steps:
+        - checkout
+        - core/ensure_pkg_manager:
+            pkg_manager: npm
+        - core/install_dependencies:
+            pkg_manager: npm
+        - core/run_script:
+            pkg_manager: npm
+            pkg_json_dir: ~/monorepo
+            script: test
+            script_args: --coverage
+            run_options: --workspace=app-name
   workflows:
     test_app:
       jobs:
         - test
+        - workspace_test

--- a/src/scripts/run-script.sh
+++ b/src/scripts/run-script.sh
@@ -1,14 +1,47 @@
 #!/bin/bash
 
-echo "Running package.json script at ${PWD}"
+if [[ -z "${PARAM_STR_SCRIPT}" ]]; then
+  echo "Cannot run package.json script because the script parameter is empty"
+
+  exit 1
+fi
+
+echo "Running package.json script '${PARAM_STR_SCRIPT}' at ${PWD}"
+
+CMD=()
+SCRIPT_ARGS=()
+RUN_OPTIONS=()
+
+if [[ -n "${PARAM_STR_SCRIPT_ARGS}" ]]; then
+  read -ra SCRIPT_ARGS <<<"${PARAM_STR_SCRIPT_ARGS}"
+fi
+
+if [[ -n "${PARAM_STR_RUN_OPTIONS}" ]]; then
+  read -ra RUN_OPTIONS <<<"${PARAM_STR_RUN_OPTIONS}"
+fi
 
 if [[ "${CURRENT_PKG_MANAGER}" == "npm" ]]; then
-  eval npm run "${PARAM_STR_SCRIPT}"
+  CMD=(npm run "${PARAM_STR_SCRIPT}")
+  CMD+=("${RUN_OPTIONS[@]}")
+
+  if [[ ${#SCRIPT_ARGS[@]} -gt 0 ]]; then
+    CMD+=(--)
+    CMD+=("${SCRIPT_ARGS[@]}")
+  fi
 elif [[ "${CURRENT_PKG_MANAGER}" == "pnpm" ]]; then
-  eval pnpm run "${PARAM_STR_SCRIPT}"
+  CMD=(pnpm)
+  CMD+=("${RUN_OPTIONS[@]}")
+  CMD+=(run "${PARAM_STR_SCRIPT}")
+  CMD+=("${SCRIPT_ARGS[@]}")
 else
   # This should not happen, but just to be on the safe side
   echo "Cannot run script with unsupported package manager '${CURRENT_PKG_MANAGER}'"
 
   exit 1
 fi
+
+echo 'Executing:'
+
+set -x
+"${CMD[@]}"
+set +x


### PR DESCRIPTION
Split `run_script` execution parameters into `script`, `script_args`, and `rub_options` so npm and pnpm can place workspace/run options in the correct package manager specific position.

Build `run_script` commands with shell argument arrays instead of eval and add early validation for missing script names.