### PR TITLE
feat: include Node.js version in dependency cache keys

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -88,6 +88,10 @@ jobs:
               echo "ensure_pkg_manager should not create package manager cache metadata"
               exit 1
             fi
+            if [ -f /tmp/node-version ]; then
+              echo "ensure_pkg_manager should not create Node.js version cache metadata"
+              exit 1
+            fi
 
   install-dependencies-npm-node-18:
     executor:
@@ -117,6 +121,10 @@ jobs:
               echo "Expected package manager cache metadata to be removed"
               exit 1
             fi
+            if [ -f /tmp/node-version ]; then
+              echo "Expected Node.js version cache metadata to be removed"
+              exit 1
+            fi
       - run: cd ~/project/sample && npm run build
   install-dependencies-pnpm-node-18:
     executor:
@@ -144,6 +152,10 @@ jobs:
             fi
             if [ -f /tmp/node-pkg-manager ]; then
               echo "Expected package manager cache metadata to be removed"
+              exit 1
+            fi
+            if [ -f /tmp/node-version ]; then
+              echo "Expected Node.js version cache metadata to be removed"
               exit 1
             fi
       - run: cd ~/project/sample && pnpm run build
@@ -181,6 +193,10 @@ jobs:
             fi
             if [ -f /tmp/node-pkg-manager ]; then
               echo "Expected package manager cache metadata to be removed"
+              exit 1
+            fi
+            if [ -f /tmp/node-version ]; then
+              echo "Expected Node.js version cache metadata to be removed"
               exit 1
             fi
       - run: cd ~/project/sample && pnpm run build
@@ -254,10 +270,14 @@ jobs:
           script: test
           script_args: --json --outputFile=results_pnpm_default.json
       - run:
-          name: Validate run_script package manager metadata ownership
+          name: Validate run_script metadata ownership
           command: |
             if [ -f /tmp/node-pkg-manager ]; then
               echo "run_script should not create package manager cache metadata"
+              exit 1
+            fi
+            if [ -f /tmp/node-version ]; then
+              echo "run_script should not create Node.js version cache metadata"
               exit 1
             fi
       - run:

--- a/src/commands/install_dependencies.yml
+++ b/src/commands/install_dependencies.yml
@@ -46,6 +46,9 @@ steps:
       working_directory: <<parameters.pkg_json_dir>>
       command: <<include(scripts/check-pkg-json.sh)>>
   - run:
+      name: Write Node.js version cache metadata
+      command: <<include(scripts/write-node-version-cache-metadata.sh)>>
+  - run:
       name: Write package manager cache metadata
       command: <<include(scripts/write-pkg-manager-cache-metadata.sh)>>
   - run:
@@ -54,8 +57,8 @@ steps:
       command: <<include(scripts/process-lockfile.sh)>>
   - restore_cache:
       keys:
-        - node-{{ arch }}-<<parameters.cache_version>>-{{ checksum "/tmp/node-pkg-manager" }}-{{ checksum "/tmp/node-lockfile" }}
-        - node-{{ arch }}-<<parameters.cache_version>>-{{ checksum "/tmp/node-pkg-manager" }}-
+        - node-{{ arch }}-<<parameters.cache_version>>-{{ checksum "/tmp/node-version" }}-{{ checksum "/tmp/node-pkg-manager" }}-{{ checksum "/tmp/node-lockfile" }}
+        - node-{{ arch }}-<<parameters.cache_version>>-{{ checksum "/tmp/node-version" }}-{{ checksum "/tmp/node-pkg-manager" }}-
   - run:
       name: Restore dependency cache
       environment:
@@ -73,7 +76,7 @@ steps:
         PARAM_STR_CACHE_MODE: prepare
       command: <<include(scripts/manage-dependency-cache.sh)>>
   - save_cache:
-      key: node-{{ arch }}-<<parameters.cache_version>>-{{ checksum "/tmp/node-pkg-manager" }}-{{ checksum "/tmp/node-lockfile" }}
+      key: node-{{ arch }}-<<parameters.cache_version>>-{{ checksum "/tmp/node-version" }}-{{ checksum "/tmp/node-pkg-manager" }}-{{ checksum "/tmp/node-lockfile" }}
       paths:
         - ~/.cache/pipeline-core-orb/dependency-cache
   - run:
@@ -83,4 +86,4 @@ steps:
       command: <<include(scripts/manage-dependency-cache.sh)>>
   - run:
       name: Remove temporary dependency metadata
-      command: rm -f /tmp/node-lockfile /tmp/node-pkg-manager
+      command: rm -f /tmp/node-lockfile /tmp/node-pkg-manager /tmp/node-version

--- a/src/scripts/write-node-version-cache-metadata.sh
+++ b/src/scripts/write-node-version-cache-metadata.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+DEST_FILE="/tmp/node-version"
+NODE_VERSION_REGEX="^v([0-9]+)\.([0-9]+)\.([0-9]+)$"
+NODE_VERSION=$(node -v)
+MAJOR=""
+
+if [[ "${NODE_VERSION}" =~ ${NODE_VERSION_REGEX} ]]; then
+  MAJOR="${BASH_REMATCH[1]}"
+else
+  echo "Could not parse Node.js version: ${NODE_VERSION}"
+  echo "Cannot write Node.js major version cache metadata"
+
+  exit 1
+fi
+
+echo "Writing Node.js major version cache metadata: ${MAJOR}"
+echo "${MAJOR}" >|"${DEST_FILE}"


### PR DESCRIPTION
The `install_dependencies` includes the Node.js runtime version in its cache key, alongside architecture, cache version, package manager, and lockfile. Only the major Node.js version is factored into the key.