### PR TITLE
feat: add `install_and_run` job

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -387,6 +387,45 @@ workflows:
           filters: *filters
       - run-script-pnpm-workspace:
           filters: *filters
+      - core/install_and_run:
+          name: install-and-run-npm
+          pkg_manager: npm
+          pkg_json_dir: ~/project/sample
+          script: test
+          script_args: --json --outputFile=results_install_and_run_npm.json
+          filters: *filters
+      - core/install_and_run:
+          name: install-and-run-default-pkg-manager-env
+          pkg_json_dir: ~/project/sample
+          script: test
+          script_args: --json --outputFile=results_install_and_run_default.json
+          pre_install_steps:
+            - run:
+                name: Validate pre-install hook placement
+                command: |
+                  if ! command -v pnpm >/dev/null 2>&1; then
+                    echo "Expected pnpm to be available before dependency installation"
+                    exit 1
+                  fi
+                  if [ -d ~/project/sample/node_modules ]; then
+                    echo "Expected dependencies not to be installed before pre-install steps"
+                    exit 1
+                  fi
+                  echo "pre-install" > /tmp/install-and-run-hook-order
+          post_install_steps:
+            - run:
+                name: Validate post-install hook placement
+                command: |
+                  if [ ! -d ~/project/sample/node_modules ]; then
+                    echo "Expected dependencies to be installed before post-install steps"
+                    exit 1
+                  fi
+                  if [ "$(cat /tmp/install-and-run-hook-order)" != "pre-install" ]; then
+                    echo "Expected pre-install hook to run before post-install hook"
+                    exit 1
+                  fi
+                  rm -f /tmp/install-and-run-hook-order
+          filters: *filters
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
@@ -412,5 +451,7 @@ workflows:
             - run-script-externally-prepared-pnpm
             - run-script-npm-workspace
             - run-script-pnpm-workspace
+            - install-and-run-npm
+            - install-and-run-default-pkg-manager-env
           context: orb-publishing
           filters: *release-filters

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 An orb to facilitate Node.js work within Studion CircleCI pipelines. Inspired by CircleCI Node Orb.\
 Key features:
+
 - Support for pnpm and npm
 - Ensure the specific version/tag of the package manager is installed
 - The default value of the package manager is picked from the environment
 - Install dependencies with caching enabled by default
 - Run scripts defined inside a package.json using a command for better composition
+- Use a streamlined job for common package script workflows
 - Use Docker executor with integrated Infisical for secure secret retrieval
 - Can only run in execution environments with Node.js pre-installed
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 description: >
-  Core commands for Node.js projects: ensure npm or pnpm package managers, install
+  Core commands and jobs for Node.js projects: ensure npm or pnpm package managers, install
   dependencies with caching, and run package.json scripts. Tailored for use within Studion pipelines.
 
 display:

--- a/src/examples/install_and_run.yml
+++ b/src/examples/install_and_run.yml
@@ -1,0 +1,25 @@
+description: |
+  Ensure a package manager, install dependencies, and run a package.json script in one reusable job.
+  Use pre_install_steps and post_install_steps when project-specific setup is needed around dependency installation.
+
+usage:
+  version: 2.1
+  orbs:
+    core: studion/core@x.y.z
+  workflows:
+    test_app:
+      jobs:
+        - core/install_and_run:
+            pkg_manager: pnpm@10.5.1
+            pkg_json_dir: ~/project/app
+            script: test
+            script_args: --coverage
+            pre_install_steps:
+              - run:
+                  name: Prepare package manager configuration
+                  command: pnpm config set verify-store-integrity true
+            post_install_steps:
+              - run:
+                  name: Generate application assets
+                  command: pnpm run generate
+                  working_directory: ~/project/app

--- a/src/jobs/install_and_run.yml
+++ b/src/jobs/install_and_run.yml
@@ -1,0 +1,99 @@
+description: >
+  Ensure a package manager, install dependencies, and run a package.json script in one reusable job.
+
+executor:
+  name: node
+  tag: <<parameters.node_tag>>
+  resource_class: <<parameters.resource_class>>
+
+parameters:
+  node_tag:
+    type: string
+    default: lts
+    description: >
+      Choose a specific cimg/node image tag for the job executor.
+  resource_class:
+    type: enum
+    enum:
+      ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: "medium"
+    description: Choose the executor resource class.
+  pkg_manager:
+    type: string
+    default: ""
+    description: |
+      Choose Node.js package manager to ensure and use. Supports npm and pnpm.
+      The package manager may follow the format <name>[@<version|tag>].
+      When omitted, the DEFAULT_PKG_MANAGER environment variable is used at runtime.
+  pkg_json_dir:
+    type: string
+    default: "."
+    description: >
+      Path to the directory containing package.json file where dependencies are installed
+      and the package manager should execute the script.
+  install_command:
+    type: string
+    default: ""
+    description: >
+      Custom command to install dependencies. Useful when default commands,
+      "npm ci" or "pnpm i --frozen-lockfile", are unsuitable.
+  cache_version:
+    type: string
+    default: "v1"
+    description: Change the default cache version if the cache needs to be cleared for some reason.
+  pre_install_steps:
+    type: steps
+    default: []
+    description: >
+      Optional steps to run after checkout and package-manager setup, but before dependency installation.
+      These steps can rely on the selected package manager being available.
+  post_install_steps:
+    type: steps
+    default: []
+    description: >
+      Optional steps to run after dependency installation, but before running the package.json script.
+      These steps can rely on installed dependencies being available.
+  script:
+    type: string
+    description: >
+      Name of the package.json script to execute.
+  script_args:
+    type: string
+    default: ""
+    description: >
+      Arguments passed to the package.json script. For npm, arguments are passed after an
+      automatically inserted -- separator. For pnpm, arguments are passed directly after
+      the script name; include -- explicitly when the script itself needs that separator.
+      Values are split on whitespace into command arguments.
+  run_options:
+    type: string
+    default: ""
+    description: >
+      Package manager specific options for the run command, including workspace selectors.
+      For npm these options are placed after the script name. For pnpm these options are placed before run.
+      Values are split on whitespace into command arguments.
+  no_output_timeout:
+    type: string
+    default: "10m"
+    description: >
+      Elapsed time the script can run without output.
+      The string is a decimal with unit suffix, such as "20m", "1.25h", "5s".
+
+steps:
+  - checkout
+  - ensure_pkg_manager:
+      pkg_manager: <<parameters.pkg_manager>>
+  - steps: <<parameters.pre_install_steps>>
+  - install_dependencies:
+      pkg_manager: <<parameters.pkg_manager>>
+      pkg_json_dir: <<parameters.pkg_json_dir>>
+      install_command: <<parameters.install_command>>
+      cache_version: <<parameters.cache_version>>
+  - steps: <<parameters.post_install_steps>>
+  - run_script:
+      pkg_manager: <<parameters.pkg_manager>>
+      pkg_json_dir: <<parameters.pkg_json_dir>>
+      script: <<parameters.script>>
+      script_args: <<parameters.script_args>>
+      run_options: <<parameters.run_options>>
+      no_output_timeout: <<parameters.no_output_timeout>>


### PR DESCRIPTION
The job that combines `ensure_pkg_manager`, `install_dependencies`, and `run_script` command into a single reusable unit. Provides the `pre_install_steps` and `post_install_steps` hooks for project-specific setup around dependency installation.