### PR TITLE
fix: preserve package script exit status in `run-script.sh`

### DIFF
--- a/src/scripts/run-script.sh
+++ b/src/scripts/run-script.sh
@@ -44,4 +44,7 @@ echo 'Executing:'
 
 set -x
 "${CMD[@]}"
+EXIT_STATUS=$?
 set +x
+
+exit "${EXIT_STATUS}"


### PR DESCRIPTION
Previously, the script executed the package command and then ran `set +x` as the final command. In non-strict shell contexts, that could allow a failed `npm run` or `pnpm run` command to be masked by the successful `set +x`.
The fix captures the command status immediately after execution, disables tracing, then exits with the captured status.