### PR TITLE
fix: make Node.js version validation strict and fail-closed

### DIFF
--- a/src/scripts/check-node-version.sh
+++ b/src/scripts/check-node-version.sh
@@ -7,18 +7,23 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
-NODE_VERSION_REGEX="v([0-9]+).([0-9]+).([0-9]+)"
+NODE_VERSION_REGEX="^v([0-9]+)\.([0-9]+)\.([0-9]+)$"
 NODE_VERSION=$(node -v)
-MAJOR=""
-MINOR=""
 
-if [[ "${NODE_VERSION}" =~ ${NODE_VERSION_REGEX} ]]; then
-  MAJOR="${BASH_REMATCH[1]}"
-  MINOR="${BASH_REMATCH[2]}"
+if [[ ! "${NODE_VERSION}" =~ ${NODE_VERSION_REGEX} ]]; then
+  echo "Unable to parse Node.js version: ${NODE_VERSION}"
+  echo "Expected Node.js version output in the form v<major>.<minor>.<patch>"
 
-  if [[ "${MAJOR}" -lt 18 || ("${MAJOR}" -eq 18 && "${MINOR}" -lt 20) ]]; then
-    echo "At least Node.js v18.20 is required!"
-
-    exit 1
-  fi
+  exit 1
 fi
+
+MAJOR="${BASH_REMATCH[1]}"
+MINOR="${BASH_REMATCH[2]}"
+
+if [[ "${MAJOR}" -lt 18 || ("${MAJOR}" -eq 18 && "${MINOR}" -lt 20) ]]; then
+  echo "At least Node.js v18.20 is required!"
+
+  exit 1
+fi
+
+echo "Detected Node.js version: ${NODE_VERSION}"


### PR DESCRIPTION
Previously, the parser used a loose regex and had no explicit failure branch when parsing failed. That meant malformed `node -v output` could pass validation.

The validation now:
- Requires output in the form `v<major>.<minor>.<patch>`
- Uses escaped literal dots and start/end anchors
- Fails explicitly if the version output cannot be parsed
- Still rejects Node.js versions below `v18.20`